### PR TITLE
func_80033750

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -132,6 +132,19 @@ struct Unk12 {
     s8 unkC3;
 };
 
+struct Unk15 {
+    u8 pad[5];
+    u8 unk5;
+    u8 pad10[0x79];
+    u16 unk80;
+    u16 unk82;
+    u8 pad82[3];
+    u8 unk87;
+    s8 unk88;
+    u8 pad5[0x3a];
+    s8 unkC3;
+};
+
 extern u8 D_800F8B30[];
 extern s8 D_801721CF;
 extern s8 D_80141BDC;

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1403,7 +1403,30 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800335E4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033694);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033750);
+void func_80033750(struct Unk15* arg0)
+{
+    s8 temp_v0;
+    s8 temp_v1;
+    u16 temp_v0_2;
+
+    arg0->unk87 = 0;
+    if ((arg0->unkC3 == 0) && (temp_v1 = arg0->unk5, (temp_v1 != 0)) && (temp_v1 != 1)) {
+        temp_v0 = arg0->unk88;
+        if (temp_v0 == 0) {
+            temp_v0_2 = arg0->unk80 & 3;
+            arg0->unk82 = temp_v0_2;
+            if (temp_v0_2 != 0) {
+                arg0->unk88 = 0xC;
+            }
+        } else {
+            arg0->unk88 = (s8)(temp_v0 - 1);
+            if (arg0->unk80 & arg0->unk82) {
+                arg0->unk87 = 1;
+                arg0->unk88 = 0;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800337DC);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1405,21 +1405,17 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033694);
 
 void func_80033750(struct Unk15* arg0)
 {
-    s8 temp_v0;
     s8 temp_v1;
-    u16 temp_v0_2;
 
     arg0->unk87 = 0;
     if ((arg0->unkC3 == 0) && (temp_v1 = arg0->unk5, (temp_v1 != 0)) && (temp_v1 != 1)) {
-        temp_v0 = arg0->unk88;
-        if (temp_v0 == 0) {
-            temp_v0_2 = arg0->unk80 & 3;
-            arg0->unk82 = temp_v0_2;
-            if (temp_v0_2 != 0) {
+        if (arg0->unk88 == 0) {
+            arg0->unk82 = arg0->unk80 & 3;
+            if (arg0->unk82 != 0) {
                 arg0->unk88 = 0xC;
             }
         } else {
-            arg0->unk88 = (s8)(temp_v0 - 1);
+            arg0->unk88--;
             if (arg0->unk80 & arg0->unk82) {
                 arg0->unk87 = 1;
                 arg0->unk88 = 0;


### PR DESCRIPTION
I think `if ((arg0->unkC3 == 0) && (temp_v1 = arg0->unk5, (temp_v1 != 0)) && (temp_v1 != 1)) {` can be better so leaving this one up for a bit
https://decomp.me/scratch/J82XH