### PR TITLE
Decompile a few related functions in the func_8002C614 call chain

### DIFF
--- a/config/SLUS_005.61.splat.yaml
+++ b/config/SLUS_005.61.splat.yaml
@@ -34,6 +34,8 @@ segments:
     subalign: 1
     subsegments:
       - [0x800, rodata]
+      - [0xA44, .rodata, 323C]
+      - [0xAC0, rodata]
       - [0x2824, c]
       - [0x323C, c]
       - [0xC594C, c]

--- a/include/common.h
+++ b/include/common.h
@@ -39,11 +39,15 @@ struct Unk {
     s8 unk4;
     s8 unk5;
     s8 unk6;
-    u8 pad5[3];
+    s8 : 8;
+    s16 x_pos_hi; // 0x08
     s16 x_pos; // 0x0A
-    s16 padc;
+    s16 y_pos_hi; // 0x0C
     s16 y_pos; // 0x0E
-    u8 pad6[0x10];
+    u8 pad10[0x5];
+    u8 unk15;
+    s32 unk18;
+    s32 unk1C;
     s32 unk20;
     s32 unk24;
     s32 unk28;
@@ -66,8 +70,10 @@ struct Unk {
     s8 unk65;
     s8 unk66;
     s8 unk67;
-    s32 unk68;
-    s8 pad69[6];
+    struct Unk_unk68* unk68;
+    u8 pad6C[0x70 - 0x6C];
+    u8 unk70;
+    s8 : 8;
     s8 unk72;
     s8 unk73;
     s8 unk74;
@@ -75,7 +81,7 @@ struct Unk {
     s8 unk76;
     s8 unk77;
     s8 unk78;
-    s8 pad79[1];
+    s8 unk79;
     s8 unk7A;
     u8 pad68[0x10];
     u16 unk8C;
@@ -83,6 +89,13 @@ struct Unk {
     u32 unk94;
     u32 pad98;
 }; // size 0x9c
+
+struct Unk_unk68 {
+    s8 unk0;
+    s8 unk1;
+    u8 unk2;
+    u8 unk3;
+};
 
 struct MiscObj {
     s8 active;
@@ -443,6 +456,17 @@ extern void (*D_8010EC10[1])();
 extern void (*D_8010F690[1])();
 extern void (*D_8010FC84[1])();
 extern void (*D_8010FDD0[1])();
+extern u8 D_8013B7D8;
+extern u8 D_8013B7DC;
+extern s16 D_8013B7E0;
+extern s16 D_8013B7E4;
+extern s16 D_8013B7E8;
+extern s16 D_8013B7EC;
+extern s16 D_8013B7F0;
+extern s16 D_8013B7F4;
+extern s16 D_8013B7F8;
+extern s16 D_8013B7FC;
+extern s16 D_8013B804;
 extern u8 D_8013BC34;
 extern s16 D_80173C7A;
 extern struct EffectObj effect_objects[0x20];
@@ -596,6 +620,11 @@ void func_8001D284();
 void func_80022730(s32*);
 void func_8002B718();
 void func_8002B288(struct Unk*);
+s32 func_8002CF98(struct Unk*, u8, s16, s16);
+s32 func_8002D1F8(struct Unk*, u8, s16);
+s32 func_8002D32C(struct Unk*, s16, s8);
+s32 func_8002D5E4(struct Unk*, s16);
+s32 func_8002D7E4(struct Unk*, s16, s16);
 void func_800E5D78(s32);
 s32 func_800E5D90(s32, s32, s32);
 void func_80016334(void);

--- a/include/common.h
+++ b/include/common.h
@@ -71,7 +71,8 @@ struct Unk {
     s8 unk66;
     s8 unk67;
     struct Unk_unk68* unk68;
-    u8 pad6C[0x70 - 0x6C];
+    s16 : 16;
+    s16 unk6E;
     u8 unk70;
     s8 : 8;
     s8 unk72;
@@ -621,7 +622,6 @@ void func_80022730(s32*);
 void func_8002B718();
 void func_8002B288(struct Unk*);
 s32 func_8002CF98(struct Unk*, u8, s16, s16);
-s32 func_8002D1F8(struct Unk*, u8, s16);
 s32 func_8002D32C(struct Unk*, s16, s8);
 s32 func_8002D5E4(struct Unk*, s16);
 s32 func_8002D7E4(struct Unk*, s16, s16);

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1529,11 +1529,97 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C2EC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C36C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C614);
+void func_8002C614(struct Unk* arg0)
+{
+    s32 temp_v0;
+    s32 temp_v1;
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C760);
+    arg0->unk70 = 0;
+    arg0->unk79 = 0;
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C808);
+    if (arg0->unk68 != NULL) {
+        func_8002C760(arg0);
+        temp_v1 = *(s32*)&arg0->x_pos_hi - arg0->unk18;
+        D_8013B7D8 = 0;
+        D_8013B7DC = 0;
+
+        if (temp_v1 != 0) {
+            if (temp_v1 > 0) {
+                func_8002CB58(arg0);
+            } else {
+                func_8002CA18(arg0);
+            }
+        }
+
+        if (*(s32*)&arg0->y_pos_hi - arg0->unk1C >= 0) {
+            func_8002CDD4(arg0);
+            if (D_8013B7D8 != 0) {
+                return;
+            }
+        } else {
+            func_8002CC98(arg0);
+        }
+
+        if (D_8013B7DC & 0xC) {
+            if ((D_8013B7DC & 3) != 0) {
+                if ((D_8013B7DC & 4) || (D_8013B804 >= -8)) {
+                    func_8002C954(arg0);
+                } else {
+                    func_8002C99C(arg0);
+                }
+            } else {
+                func_8002D25C(arg0);
+            }
+        } else if ((D_8013B7DC & 3) != 0) {
+            func_8002D490(arg0);
+        }
+
+        func_8002C808(arg0);
+    }
+}
+
+void func_8002C760(struct Unk* arg0)
+{
+    struct Unk_unk68* temp_v1 = arg0->unk68;
+    u16 temp_a1 = arg0->x_pos;
+    u16 temp_v0 = temp_v1->unk0;
+
+    D_8013B7E8 = temp_v1->unk0;
+    D_8013B7EC = temp_v1->unk1;
+    D_8013B7E0 = temp_v1->unk2;
+    D_8013B7E4 = temp_v1->unk3;
+
+    D_8013B7F0 = temp_a1;
+    D_8013B7F4 = arg0->y_pos;
+
+    if (arg0->unk15 == 0) {
+        D_8013B7F8 = temp_a1 + temp_v0;
+    } else {
+        D_8013B7F8 = temp_a1 - temp_v0;
+    }
+    D_8013B7FC = D_8013B7F4 + D_8013B7EC;
+}
+
+void func_8002C808(struct Unk* arg0)
+{
+    arg0->unk70 = 0;
+    arg0->unk79 = 0;
+    if (arg0->unk68 != NULL) {
+        func_8002C760(arg0);
+        if (func_8002D5E4(arg0, D_8013B7F8 - D_8013B7E0 - 1)) {
+            arg0->unk70 |= 2;
+        }
+        if (func_8002D5E4(arg0, D_8013B7F8 + D_8013B7E0)) {
+            arg0->unk70 |= 1;
+        }
+        if (func_8002D32C(arg0, D_8013B7F4 + D_8013B7EC + D_8013B7E4, 1)) {
+            arg0->unk70 |= 8;
+        }
+        if (func_8002D32C(arg0, D_8013B7F4 + D_8013B7EC - D_8013B7E4 - 1, 0)) {
+            arg0->unk70 |= 4;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C954);
 
@@ -1553,7 +1639,48 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CC98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CD70);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CDD4);
+void func_8002CDD4(struct Unk* arg0)
+{
+    s16 vOffset;
+    s32 resultLeft, resultRight, primaryResult;
+    u8 checkLeft, checkRight, checkAdditional;
+
+    vOffset = D_8013B7FC + D_8013B7E4;
+    resultLeft = func_8002D7E4(arg0, D_8013B7F8 - D_8013B7E0, vOffset);
+    resultRight = func_8002D7E4(arg0, D_8013B7F8 + D_8013B7E0 - 1, vOffset);
+
+    if (func_8002CF98(arg0, func_8002D7E4(arg0, D_8013B7F8, vOffset), D_8013B7F8, vOffset) == 0) {
+        if (arg0->unk67 == 0) {
+            primaryResult = 0;
+
+            checkLeft = resultLeft;
+            if (checkLeft && checkLeft < 0x20) {
+                primaryResult = 1;
+            }
+
+            checkRight = resultRight;
+            if (checkRight && checkRight < 0x20) {
+                primaryResult = 1;
+            }
+
+            checkAdditional = func_8002D7E4(arg0, D_8013B7F8, vOffset + 0x10);
+            if (checkAdditional && checkAdditional < 0x20) {
+                primaryResult = 1;
+            }
+
+            if (primaryResult) {
+                arg0->y_pos += 0x10;
+                if (func_8002CF98(arg0, checkAdditional, D_8013B7F8, vOffset + 0x10)) {
+                    return;
+                }
+            }
+        }
+
+        if (func_8002D1F8(arg0, resultLeft, vOffset) == 0) {
+            func_8002D1F8(arg0, resultRight, vOffset);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CF98);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1655,21 +1655,21 @@ void func_8002CDD4(struct Unk* arg0)
     if (func_8002CF98(arg0, temp_s5, D_8013B7F8, temp_v0) == 0) {
         if (arg0->unk67 == 0) {
             var_s0 = 0;
-            if ((temp_s3 > 0) && (temp_s3 < 0x20)) {
+            if (temp_s3 > 0 && temp_s3 < 0x20) {
                 var_s0 = 1;
             }
-            if ((temp_s4 > 0) && (temp_s4 < 0x20)) {
+            if (temp_s4 > 0 && temp_s4 < 0x20) {
                 var_s0 = 1;
             }
 
             temp_v0_4 = func_8002D7E4(arg0, D_8013B7F8, (temp_v0 + 0x10));
-            if ((temp_v0_4 > 0) && (temp_v0_4 < 0x20)) {
+            if (temp_v0_4 > 0 && temp_v0_4 < 0x20) {
                 var_s0 = 1;
             }
 
-            if (var_s0 != 0) {
+            if (var_s0) {
                 arg0->y_pos += 0x10;
-                if (func_8002CF98(arg0, temp_v0_4, D_8013B7F8, (temp_v0 + 0x10)) != 0) {
+                if (func_8002CF98(arg0, temp_v0_4, D_8013B7F8, temp_v0 + 0x10)) {
                     return;
                 }
             }
@@ -1685,12 +1685,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CF98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002D180);
 
-s32 func_8002D1F8(struct Unk* arg0, s32 arg1, s32 arg2)
+s32 func_8002D1F8(struct Unk* arg0, u8 arg1, s32 arg2)
 {
-    s32 temp_a1;
-
-    temp_a1 = arg1 & 0xFF;
-    switch (temp_a1) {
+    switch (arg1) {
     case 0x21:
     case 0x22:
     case 0x38:

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1641,43 +1641,42 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CD70);
 
 void func_8002CDD4(struct Unk* arg0)
 {
-    s16 vOffset;
-    s32 resultLeft, resultRight, primaryResult;
-    u8 checkLeft, checkRight, checkAdditional;
+    u8 temp_s3;
+    u8 temp_s4;
+    u8 temp_s5;
+    u8 temp_v0_4;
+    s32 var_s0;
+    s16 temp_v0 = D_8013B7FC + D_8013B7E4;
 
-    vOffset = D_8013B7FC + D_8013B7E4;
-    resultLeft = func_8002D7E4(arg0, D_8013B7F8 - D_8013B7E0, vOffset);
-    resultRight = func_8002D7E4(arg0, D_8013B7F8 + D_8013B7E0 - 1, vOffset);
+    temp_s3 = func_8002D7E4(arg0, D_8013B7F8 - D_8013B7E0, temp_v0);
+    temp_s4 = func_8002D7E4(arg0, D_8013B7F8 + D_8013B7E0 - 1, temp_v0);
+    temp_s5 = func_8002D7E4(arg0, D_8013B7F8, temp_v0);
 
-    if (func_8002CF98(arg0, func_8002D7E4(arg0, D_8013B7F8, vOffset), D_8013B7F8, vOffset) == 0) {
+    if (func_8002CF98(arg0, temp_s5, D_8013B7F8, temp_v0) == 0) {
         if (arg0->unk67 == 0) {
-            primaryResult = 0;
-
-            checkLeft = resultLeft;
-            if (checkLeft && checkLeft < 0x20) {
-                primaryResult = 1;
+            var_s0 = 0;
+            if ((temp_s3 > 0) && (temp_s3 < 0x20)) {
+                var_s0 = 1;
+            }
+            if ((temp_s4 > 0) && (temp_s4 < 0x20)) {
+                var_s0 = 1;
             }
 
-            checkRight = resultRight;
-            if (checkRight && checkRight < 0x20) {
-                primaryResult = 1;
+            temp_v0_4 = func_8002D7E4(arg0, D_8013B7F8, (temp_v0 + 0x10));
+            if ((temp_v0_4 > 0) && (temp_v0_4 < 0x20)) {
+                var_s0 = 1;
             }
 
-            checkAdditional = func_8002D7E4(arg0, D_8013B7F8, vOffset + 0x10);
-            if (checkAdditional && checkAdditional < 0x20) {
-                primaryResult = 1;
-            }
-
-            if (primaryResult) {
+            if (var_s0 != 0) {
                 arg0->y_pos += 0x10;
-                if (func_8002CF98(arg0, checkAdditional, D_8013B7F8, vOffset + 0x10)) {
+                if (func_8002CF98(arg0, temp_v0_4, D_8013B7F8, (temp_v0 + 0x10)) != 0) {
                     return;
                 }
             }
         }
 
-        if (func_8002D1F8(arg0, resultLeft, vOffset) == 0) {
-            func_8002D1F8(arg0, resultRight, vOffset);
+        if (func_8002D1F8(arg0, temp_s3, temp_v0) == 0) {
+            func_8002D1F8(arg0, temp_s4, temp_v0);
         }
     }
 }
@@ -1686,7 +1685,27 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CF98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002D180);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002D1F8);
+s32 func_8002D1F8(struct Unk* arg0, s32 arg1, s32 arg2)
+{
+    s32 temp_a1;
+
+    temp_a1 = arg1 & 0xFF;
+    switch (temp_a1) {
+    case 0x21:
+    case 0x22:
+    case 0x38:
+    case 0x39:
+    case 0x3A:
+    case 0x3C:
+    case 0x3E:
+    case 0x3F:
+        D_8013B7DC |= 8;
+        D_8013B804 = -arg0->unk6E;
+        return -1;
+    default:
+        return 0;
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002D25C);
 


### PR DESCRIPTION
Trying to track down more of the shape of the big `Unk` struct.

Functions in green are decompiled, red are not decompiled, and blue aren't yet on the [high priority functions](https://github.com/sozud/mmx4/wiki/Getting-Started#high-priority-functions) list.

```mermaid
stateDiagram-v2
    func_8002C614:::r --> func_8002C760:::g
    func_8002C614:::r --> func_8002CDD4:::g
    func_8002CDD4:::g --> func_8002D1F8:::g
    func_8002CDD4:::g --> func_8002CF98:::r
    func_8002CF98:::r --> func_8002D7E4:::r
    func_8002CDD4:::g --> func_8002D7E4:::r
    func_8002C614:::r --> func_8002C808:::g
    func_8002C808:::g --> func_8002D32C:::r
    func_8002D32C:::r --> func_8002D41C:::g
    func_8002D32C:::r --> func_8002D724:::r
    func_8002C808:::g --> func_8002C760:::g
    func_8002C808:::g --> func_8002D5E4:::r
    func_8002D5E4:::r --> func_8002D6BC:::r
    func_8002D5E4:::r --> func_8002D724:::r
    func_8002C614:::r --> func_8002D25C:::r
    func_8002D25C:::r --> func_8002D32C:::r
    func_8002C614:::r --> func_8002D490:::b
    func_8002D490:::b --> func_8002D5E4:::r
    func_8002C614:::r --> func_8002C954:::b
    func_8002C954:::b --> func_8002D25C:::r
    func_8002C954:::b --> func_8002D490:::b
    func_8002C614:::r --> func_8002CA18:::b
    func_8002CA18:::b --> func_8002D7E4:::r
    func_8002C614:::r --> func_8002C99C:::b
    func_8002C99C:::b --> func_8002D25C:::r
    func_8002C99C:::b --> func_8002D490:::b
    func_8002C614:::r --> func_8002CB58:::b
    func_8002CB58:::b --> func_8002D7E4:::r
    func_8002C614:::g --> func_8002CC98:::b
    func_8002CC98:::b --> func_8002D7E4:::r

    classDef r fill:#f00,color:white,stroke:#c00
    classDef g fill:#0c0,color:white,stroke:#0a0
```

Thanks @Mc-muffin for the assist on https://decomp.me/scratch/sDyJD!