### PR TITLE
Decompile functions in the func_8009ED70 call chain

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -32,6 +32,14 @@ typedef unsigned long long u64;
 #include "psy-q-4.0/LIBCD.H"
 #include "psy-q-4.0/LIBPRESS.H"
 
+typedef union {
+    s32 val;
+    struct {
+        s16 lo;
+        s16 hi;
+    } i;
+} f32;
+
 struct Unk {
     s8 active;
     s8 id; // 0x01
@@ -41,10 +49,8 @@ struct Unk {
     s8 unk5;
     s8 unk6;
     s8 : 8;
-    s16 x_pos_hi; // 0x08
-    u16 x_pos; // 0x0A
-    s16 y_pos_hi; // 0x0C
-    u16 y_pos; // 0x0E
+    f32 x_pos; // 0x8 and 0xA
+    f32 y_pos; // 0xC and 0xE
     u8 pad10[0x4];
     s8 unk14;
     u8 unk15;

--- a/include/common.h
+++ b/include/common.h
@@ -12,6 +12,7 @@
 __asm__(".include \"macro.inc\"\n");
 
 #define NULL ((void*)0)
+#define FIXED(x) ((s32)((x)*0x10000))
 
 typedef signed char s8;
 typedef signed short s16;
@@ -41,11 +42,13 @@ struct Unk {
     s8 unk6;
     s8 : 8;
     s16 x_pos_hi; // 0x08
-    s16 x_pos; // 0x0A
+    u16 x_pos; // 0x0A
     s16 y_pos_hi; // 0x0C
-    s16 y_pos; // 0x0E
-    u8 pad10[0x5];
+    u16 y_pos; // 0x0E
+    u8 pad10[0x4];
+    s8 unk14;
     u8 unk15;
+    u8 unk16;
     s32 unk18;
     s32 unk1C;
     s32 unk20;
@@ -60,7 +63,8 @@ struct Unk {
     s8 pad43[9];
     s32 unk50;
     s32 unk54;
-    s8 pad55[5];
+    s8 pad55[4];
+    s8 unk5C;
     s8 unk5D;
     u8 pad2f[3];
     s8 unk61;
@@ -412,6 +416,7 @@ extern s8 D_801721CF;
 extern s8 D_80141BDC;
 extern struct Unk5 D_800F0E18[];
 extern s32 D_80137CC0;
+extern s32 D_801418C8;
 extern s8 D_801419B3;
 extern s8 D_80141A07;
 extern s8 D_80141A5B;
@@ -444,8 +449,8 @@ extern void (*g_TitleScalingXUpdateFuncs[1])();
 extern void (*D_8010B4C4[1])();
 extern void (*D_8010BEC8[1])();
 extern s16* D_801F8300;
-extern u16 D_801419BA;
-extern u16 D_801419BE;
+extern u16 D_801419BA[];
+extern u16 D_801419BE[];
 extern void (*g_MegamanRelatedUpdateFuncs[1])();
 extern void (*g_MegamanInBriefingRoomUpdateFuncs[1])();
 extern void (*D_8010E6FC[1])();
@@ -495,7 +500,7 @@ extern u8 D_80171EA9;
 extern s32 D_80166D68;
 extern s32 D_8012F46C;
 extern RECT D_800EE450;
-extern s16 D_8013E2E8;
+extern u16 D_8013E2E8;
 extern s32 D_8013BD44;
 extern s16 D_80141BD2;
 extern void (*func_8001D064)(void);
@@ -609,6 +614,7 @@ void func_8001E6BC(struct Unk800F2294* arg0);
 
 s32 func_800E5FF4(s32, s32, u8*);
 void func_800AE6B4(s32*);
+struct Unk* func_800AFAB4(s8, s16, s16, s8);
 void func_80027FA8();
 void func_8002F048();
 void func_800D46F4();

--- a/include/func_tables.h
+++ b/include/func_tables.h
@@ -4078,7 +4078,7 @@ void func_8009EAA4(struct Unk* arg0);
 
 // D_80109160
 void func_8009EBA8(void);
-void func_8009ED70(void);
+void func_8002C808(struct Unk* arg0);
 void func_8009EE40(void);
 void func_8009EE60(void);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1193,11 +1193,9 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80027FA8);
 
 void func_80028070(struct Unk* arg0)
 {
-    arg0->x_pos = (D_801419BA + arg0->unk40);
-    do {
-    } while (0); // hmmmm inlines?
-    arg0->y_pos = (D_801419BE + arg0->unk42);
-    func_80027FA8();
+    arg0->x_pos = D_801419BA[0] + arg0->unk40;
+    arg0->y_pos = D_801419BE[0] + arg0->unk42;
+    func_80027FA8(arg0);
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800280BC);
@@ -1469,7 +1467,26 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B160);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B1E8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B288);
+void func_8002B288(struct Unk* arg0)
+{
+    s32 temp_v0;
+    u16 var_v0;
+    s8 temp_v1;
+    u16 var_a0;
+
+    arg0->unk3 = 0;
+    if (arg0->unk14 < 0) {
+        var_v0 = arg0->x_pos;
+        var_a0 = arg0->y_pos;
+    } else {
+        temp_v0 = arg0->unk14 * 0x54 / 2;
+        var_v0 = arg0->x_pos - D_801419BA[temp_v0];
+        var_a0 = arg0->y_pos - D_801419BE[temp_v0];
+    }
+    if ((((var_v0 + 0x20) & 0xFFFF) < 0x180U) && (((var_a0 + 0x20) & 0xFFFF) < 0x130U)) {
+        arg0->unk3 = 1;
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B318);
 
@@ -1491,7 +1508,22 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B468);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B560);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B694);
+void func_8002B694(struct Unk* arg0)
+{
+    *(s32*)&arg0->x_pos_hi += arg0->unk20;
+    *(s32*)&arg0->y_pos_hi -= arg0->unk24;
+
+    if (arg0->unk15) {
+        arg0->unk20 += arg0->unk28;
+    } else {
+        arg0->unk20 -= arg0->unk28;
+    }
+
+    arg0->unk24 -= arg0->unk2C;
+    if (arg0->unk24 < FIXED(-6.5)) {
+        arg0->unk24 = FIXED(-6.5);
+    }
+}
 
 void func_8002B718(struct Unk19* arg0)
 {
@@ -1499,7 +1531,19 @@ void func_8002B718(struct Unk19* arg0)
     arg0->unkC -= arg0->unk24;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B73C);
+u8 func_8002B73C()
+{
+    u16 temp = D_8013E2E8 * 3;
+    u32 temp_v1;
+    u8 pad[2];
+
+    temp_v1 = temp >> 8;
+    D_8013E2E8 += temp_v1;
+    D_8013E2E8 &= 0xFF;
+    D_8013E2E8 |= temp_v1 << 8;
+
+    return D_8013E2E8;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B780);
 
@@ -1531,9 +1575,8 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C36C);
 
 // megaman falls through floor in intro stage if nopped out
 // asm(".rept 81 ; nop ; .endr");
-void CollisionRelated(struct Unk* arg0)
+void CollisionRelated(struct Unk* arg0) // was func_8002C614
 {
-    s32 temp_v0;
     s32 temp_v1;
 
     arg0->unk70 = 0;
@@ -7551,7 +7594,28 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8009EB6C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8009EBA8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8009ED70);
+void func_8009ED70(struct Unk* arg0)
+{
+    func_80015DC8(arg0);
+    func_8002B694(arg0);
+    func_8002D9BC(arg0);
+
+    if (func_8002BB80(arg0, &D_801418C8) != 0) {
+        if (arg0->unk2 & 0x40) {
+        label:
+            func_800AF808(arg0);
+        }
+    } else if (!(arg0->unk2 & 0x40) || (CollisionRelated(arg0), arg0->unk70 == 0)) {
+        if (func_8002B160(arg0) == 0) {
+            func_8002B288(arg0);
+            return;
+        }
+    } else {
+        goto label; // unfortunately seems to be necessary for a match
+    }
+
+    arg0->unk4++;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8009EE40);
 
@@ -8399,15 +8463,41 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF658);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF6A0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF808);
+void func_800AF808(struct Unk* arg0)
+{
+    func_800AF828(arg0, 0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF828);
+void func_800AF828(struct Unk* arg0, s8 arg1)
+{
+    func_800AFAB4(arg1, arg0->x_pos, arg0->y_pos, (func_8002B73C() & 1) ^ 1);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF878);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF95C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AFAB4);
+struct Unk* func_800AFAB4(s8 arg0, s16 x, s16 y, s8 arg3)
+{
+    struct Unk* temp_v0 = func_8002AD3C();
+    if (temp_v0 != NULL) {
+        temp_v0->active = 0x21;
+        temp_v0->id = 4;
+        temp_v0->unk2 = arg0;
+        temp_v0->unk4 = 0;
+        temp_v0->unk5 = 0;
+        temp_v0->unk6 = 0;
+        temp_v0->unk5C = arg3;
+        temp_v0->x_pos = x;
+        temp_v0->x_pos_hi = 0;
+        temp_v0->y_pos = y;
+        temp_v0->y_pos_hi = 0;
+        temp_v0->unk15 = 0;
+        temp_v0->unk14 = 0;
+        temp_v0->unk16 = 1;
+    }
+    return temp_v0;
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AFB50);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1193,8 +1193,8 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80027FA8);
 
 void func_80028070(struct Unk* arg0)
 {
-    arg0->x_pos = D_801419BA[0] + arg0->unk40;
-    arg0->y_pos = D_801419BE[0] + arg0->unk42;
+    arg0->x_pos.i.hi = D_801419BA[0] + arg0->unk40;
+    arg0->y_pos.i.hi = D_801419BE[0] + arg0->unk42;
     func_80027FA8(arg0);
 }
 
@@ -1470,20 +1470,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B1E8);
 void func_8002B288(struct Unk* arg0)
 {
     s32 temp_v0;
-    u16 var_v0;
-    s8 temp_v1;
-    u16 var_a0;
+    s16 var_v0;
+    s16 var_a0;
 
     arg0->unk3 = 0;
     if (arg0->unk14 < 0) {
-        var_v0 = arg0->x_pos;
-        var_a0 = arg0->y_pos;
+        var_v0 = arg0->x_pos.i.hi;
+        var_a0 = arg0->y_pos.i.hi;
     } else {
-        temp_v0 = arg0->unk14 * 0x54 / 2;
-        var_v0 = arg0->x_pos - D_801419BA[temp_v0];
-        var_a0 = arg0->y_pos - D_801419BE[temp_v0];
+        temp_v0 = arg0->unk14 * 42;
+        var_v0 = arg0->x_pos.i.hi - D_801419BA[temp_v0];
+        var_a0 = arg0->y_pos.i.hi - D_801419BE[temp_v0];
     }
-    if ((((var_v0 + 0x20) & 0xFFFF) < 0x180U) && (((var_a0 + 0x20) & 0xFFFF) < 0x130U)) {
+    if (var_v0 >= -0x20 && var_v0 < 0x160 && var_a0 >= -0x20 && var_a0 < 0x110) {
         arg0->unk3 = 1;
     }
 }
@@ -1510,8 +1509,8 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002B560);
 
 void func_8002B694(struct Unk* arg0)
 {
-    *(s32*)&arg0->x_pos_hi += arg0->unk20;
-    *(s32*)&arg0->y_pos_hi -= arg0->unk24;
+    arg0->x_pos.val += arg0->unk20;
+    arg0->y_pos.val -= arg0->unk24;
 
     if (arg0->unk15) {
         arg0->unk20 += arg0->unk28;
@@ -1584,7 +1583,7 @@ void CollisionRelated(struct Unk* arg0) // was func_8002C614
 
     if (arg0->unk68 != NULL) {
         func_8002C760(arg0);
-        temp_v1 = *(s32*)&arg0->x_pos_hi - arg0->unk18;
+        temp_v1 = arg0->x_pos.val - arg0->unk18;
         D_8013B7D8 = 0;
         D_8013B7DC = 0;
 
@@ -1596,7 +1595,7 @@ void CollisionRelated(struct Unk* arg0) // was func_8002C614
             }
         }
 
-        if (*(s32*)&arg0->y_pos_hi - arg0->unk1C >= 0) {
+        if (arg0->y_pos.val - arg0->unk1C >= 0) {
             func_8002CDD4(arg0);
             if (D_8013B7D8 != 0) {
                 return;
@@ -1626,7 +1625,7 @@ void CollisionRelated(struct Unk* arg0) // was func_8002C614
 void func_8002C760(struct Unk* arg0)
 {
     struct Unk_unk68* temp_v1 = arg0->unk68;
-    u16 temp_a1 = arg0->x_pos;
+    u16 temp_a1 = arg0->x_pos.i.hi;
     u16 temp_v0 = temp_v1->unk0;
 
     D_8013B7E8 = temp_v1->unk0;
@@ -1635,7 +1634,7 @@ void func_8002C760(struct Unk* arg0)
     D_8013B7E4 = temp_v1->unk3;
 
     D_8013B7F0 = temp_a1;
-    D_8013B7F4 = arg0->y_pos;
+    D_8013B7F4 = arg0->y_pos.i.hi;
 
     if (arg0->unk15 == 0) {
         D_8013B7F8 = temp_a1 + temp_v0;
@@ -1713,7 +1712,7 @@ void func_8002CDD4(struct Unk* arg0)
             }
 
             if (var_s0) {
-                arg0->y_pos += 0x10;
+                arg0->y_pos.i.hi += 0x10;
                 if (func_8002CF98(arg0, temp_v0_4, D_8013B7F8, temp_v0 + 0x10)) {
                     return;
                 }
@@ -8470,7 +8469,7 @@ void func_800AF808(struct Unk* arg0)
 
 void func_800AF828(struct Unk* arg0, s8 arg1)
 {
-    func_800AFAB4(arg1, arg0->x_pos, arg0->y_pos, (func_8002B73C() & 1) ^ 1);
+    func_800AFAB4(arg1, arg0->x_pos.i.hi, arg0->y_pos.i.hi, (func_8002B73C() & 1) ^ 1);
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF878);
@@ -8488,10 +8487,10 @@ struct Unk* func_800AFAB4(s8 arg0, s16 x, s16 y, s8 arg3)
         temp_v0->unk5 = 0;
         temp_v0->unk6 = 0;
         temp_v0->unk5C = arg3;
-        temp_v0->x_pos = x;
-        temp_v0->x_pos_hi = 0;
-        temp_v0->y_pos = y;
-        temp_v0->y_pos_hi = 0;
+        temp_v0->x_pos.i.hi = x;
+        temp_v0->x_pos.i.lo = 0;
+        temp_v0->y_pos.i.hi = y;
+        temp_v0->y_pos.i.lo = 0;
         temp_v0->unk15 = 0;
         temp_v0->unk14 = 0;
         temp_v0->unk16 = 1;


### PR DESCRIPTION
```mermaid
stateDiagram-v2
    func_8009ED70:::g --> func_8002BB80:::b
    func_8009ED70:::g --> func_8002B160:::b
    func_8009ED70:::g --> func_8002B288:::g
    func_8009ED70:::g --> func_8002D9BC:::b
    func_8002D9BC:::b --> func_8002BB80:::b
    func_8009ED70:::g --> func_800AF808:::g
    func_800AF808:::g --> func_800AF828:::g
    func_800AF828:::g --> func_800AFAB4:::g
    func_800AFAB4:::g --> func_8002AD3C:::b
    func_800AF828:::g --> func_8002B73C:::g
    func_8009ED70:::g --> func_80015DC8:::r
    func_8009ED70:::g --> func_8002C614:::g
    func_8002C614:::g --> ...:::r
    func_8009ED70:::g --> func_8002B694:::g
    classDef r fill:#f00,color:white,stroke:#c00
    classDef g fill:#0c0,color:white,stroke:#0a0
```