### PR TITLE
Unify playerobj usages

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -101,6 +101,76 @@ struct Unk {
     u32 pad98;
 }; // size 0x9c
 
+// similar to Unk
+struct PlayerObj {
+    s8 active;
+    s8 id; // 0x01
+    s8 unk2;
+    s8 unk3;
+    s8 state;
+    s8 unk5;
+    s8 unk6;
+    s8 : 8;
+    f32 x_pos; // 0x8 and 0xA
+    f32 y_pos; // 0xC and 0xE
+    u8 pad10[0x4];
+    s8 unk14;
+    u8 unk15;
+    u8 unk16;
+    s32 unk18;
+    s32 unk1C;
+    s32 unk20;
+    s32 unk24;
+    s32 unk28;
+    s32 unk2C;
+    u8 pad30[0x8];
+    s16 animation_speed;
+    u8 pad39[5];
+    u16 unk40;
+    u16 unk42;
+    s8 pad43[9];
+    s32 unk50;
+    s32 unk54;
+    s8 pad55[4];
+    s8 unk5C;
+    s8 unk5D;
+    u8 pad2f[3];
+    s8 unk61;
+    s8 unk62;
+    s8 unk63;
+    s8 unk64;
+    s8 unk65;
+    s8 unk66;
+    s8 unk67;
+    struct Unk_unk68* unk68;
+    s16 : 16;
+    s16 unk6E;
+    u8 unk70;
+    s8 : 8;
+    s8 unk72;
+    s8 unk73;
+    s8 unk74;
+    s8 unk75;
+    s8 unk76;
+    s8 unk77;
+    s8 unk78;
+    s8 unk79;
+    s8 unk7A;
+    u8 pad68[4];
+    u16 unk80;
+    u16 unk82;
+    u8 pad82[3];
+    u8 unk87;
+    s8 unk88;
+    u16 unk8C;
+    u32 unk90;
+    u32 unk94;
+    u8 pad98[44];
+    s8 unkC0;
+    s8 padC0[2];
+    s8 unkC3;
+}; // size ?
+
 struct Unk_unk68 {
     s8 unk0;
     s8 unk1;

--- a/include/func_tables.h
+++ b/include/func_tables.h
@@ -827,7 +827,7 @@ void func_80032D28(void);
 void func_80032B50(void);
 
 // D_800F8B44
-void func_80035848(struct Unk* arg0);
+void func_80035848(struct PlayerObj* arg0);
 void func_800358A4(struct Unk* arg0);
 void func_80035A24(struct Unk* arg0);
 
@@ -4078,7 +4078,7 @@ void func_8009EAA4(struct Unk* arg0);
 
 // D_80109160
 void func_8009EBA8(void);
-void func_8002C808(struct Unk* arg0);
+void func_8002C808(struct PlayerObj* arg0);
 void func_8009EE40(void);
 void func_8009EE60(void);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1703,7 +1703,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002C36C);
 
 // megaman falls through floor in intro stage if nopped out
 // asm(".rept 81 ; nop ; .endr");
-void CollisionRelated(struct Unk* arg0) // was func_8002C614
+void CollisionRelated(struct PlayerObj* arg0) // was func_8002C614
 {
     s32 temp_v1;
 
@@ -1751,7 +1751,7 @@ void CollisionRelated(struct Unk* arg0) // was func_8002C614
     }
 }
 
-void func_8002C760(struct Unk* arg0)
+void func_8002C760(struct PlayerObj* arg0)
 {
     struct Unk_unk68* temp_v1 = arg0->unk68;
     u16 temp_a1 = arg0->x_pos.i.hi;
@@ -1773,7 +1773,7 @@ void func_8002C760(struct Unk* arg0)
     D_8013B7FC = D_8013B7F4 + D_8013B7EC;
 }
 
-void func_8002C808(struct Unk* arg0)
+void func_8002C808(struct PlayerObj* arg0)
 {
     arg0->unk70 = 0;
     arg0->unk79 = 0;
@@ -1812,7 +1812,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CC98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CD70);
 
-void func_8002CDD4(struct Unk* arg0)
+void func_8002CDD4(struct PlayerObj* arg0)
 {
     u8 temp_s3;
     u8 temp_s4;
@@ -1858,7 +1858,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002CF98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002D180);
 
-s32 func_8002D1F8(struct Unk* arg0, u8 arg1, s32 arg2)
+s32 func_8002D1F8(struct PlayerObj* arg0, u8 arg1, s32 arg2)
 {
     switch (arg1) {
     case 0x21:
@@ -2143,7 +2143,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033368);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033414);
 
-s32 func_80033494(struct Unk7* arg0)
+s32 func_80033494(struct PlayerObj* arg0)
 {
     if (func_80033694() != 0) {
         func_80034754(arg0);
@@ -2164,7 +2164,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800335E4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033694);
 
-void func_80033750(struct Unk15* arg0)
+void func_80033750(struct PlayerObj* arg0)
 {
     s8 temp_v1;
 
@@ -2213,7 +2213,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80033FF0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800340BC);
 
-s32 func_80034100(struct Unk3* arg0)
+s32 func_80034100(struct PlayerObj* arg0)
 {
     if (D_801721CF != 0) {
         func_80034F7C();
@@ -2336,7 +2336,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800355C0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80035694);
 
-void func_80035848(struct Unk* arg0)
+void func_80035848(struct PlayerObj* arg0)
 {
     func_800350A4(arg0, 1);
     func_8001540C(1, 0xD, arg0);
@@ -2578,7 +2578,7 @@ void func_800397E8(struct Unk11* arg0)
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80039808);
 
-s32 func_80039880(struct Unk12* arg0)
+s32 func_80039880(struct PlayerObj* arg0)
 {
     if (arg0->unk2 == 0) {
         return 0;


### PR DESCRIPTION
This unifies some usages of PlayerObj based on the new object trace data. I suspect that the way these objects are set up is like

```
struct {
 struct Header header;
 struct Player player;
};
```
And all objects have the header part and there's extra data depending on the type of object. The smallest object is 0x30 bytes so maybe that is the header part?