### PR TITLE
Integrate all remaining trivial effect update funcs

### DIFF
--- a/include/func_tables.h
+++ b/include/func_tables.h
@@ -4826,189 +4826,224 @@ void func_800B55AC(void);
 void func_800B56D4(void);
 
 // D_8010A798
-void func_800B5730(void);
-void func_800B5798(void);
+extern void (*D_8010A798[])(struct EffectObj*);
+void func_800B5730(struct EffectObj*);
+void func_800B5798(struct EffectObj*);
 
 // D_8010AFAC
-void func_800B58DC(void);
-void func_800B58F4(void);
+extern void (*D_8010AFAC[])(struct EffectObj*);
+void func_800B58DC(struct EffectObj*);
+void func_800B58F4(struct EffectObj*);
 
 // D_8010B34C
-void func_800B599C(void);
-void func_800B5B54(void);
+extern void (*D_8010B34C[])(struct EffectObj*);
+void func_800B599C(struct EffectObj*);
+void func_800B5B54(struct EffectObj*);
 
 // D_8010B3C0
-void func_800B5D04(void);
-void func_800B5E2C(void);
+extern void (*D_8010B3C0[])(struct EffectObj*);
+void func_800B5D04(struct EffectObj*);
+void func_800B5E2C(struct EffectObj*);
 
 // D_8010B444
-void func_800B5EB0(void);
-void func_800B5EEC(void);
-void func_800B6060(void);
+extern void (*D_8010B444[])(struct EffectObj*);
+void func_800B5EB0(struct EffectObj*);
+void func_800B5EEC(struct EffectObj*);
+void func_800B6060(struct EffectObj*);
 
 // D_8010B450
-void func_800B649C(void);
-void func_800B64BC(void);
+extern void (*D_8010B450[])(struct EffectObj*);
+void func_800B649C(struct EffectObj*);
+void func_800B64BC(struct EffectObj*);
 
 // D_8010B458
-void func_800B6660(void);
+extern void (*D_8010B458[])(struct EffectObj*);
+void func_800B6660(struct EffectObj*);
 
 // D_8010B45C
-void func_800B6A48(void);
-void func_800B6A90(void);
+extern void (*D_8010B45C[])(struct EffectObj*);
+void func_800B6A48(struct EffectObj*);
+void func_800B6A90(struct EffectObj*);
 
 // D_8010B4C4
+extern void (*D_8010B4C4[])(struct EffectObj*);
 void func_800B6B54(s32 arg0);
 void func_800B6C74(s32 arg0);
 void func_800B6C94(s32 arg0);
 
 // D_8010B4D8
-void func_800B70B4(void);
-void func_800B70EC(void);
+extern void (*D_8010B4D8[])(struct EffectObj*);
+void func_800B70B4(struct EffectObj*);
+void func_800B70EC(struct EffectObj*);
 
 // D_8010B4E0
-void func_800B7140(void);
-void func_800B72C4(void);
-void func_800B7328(void);
-void func_800B73D4(void);
-void func_800B7480(void);
-void func_800B7520(void);
+extern void (*D_8010B4E0[])(struct EffectObj*);
+void func_800B7140(struct EffectObj*);
+void func_800B72C4(struct EffectObj*);
+void func_800B7328(struct EffectObj*);
+void func_800B73D4(struct EffectObj*);
+void func_800B7480(struct EffectObj*);
+void func_800B7520(struct EffectObj*);
 
 // D_8010B4F8
-void func_800B7604(void);
-void func_800B7630(void);
-void func_800B7668(void);
+extern void (*D_8010B4F8[])(struct EffectObj*);
+void func_800B7604(struct EffectObj*);
+void func_800B7630(struct EffectObj*);
+void func_800B7668(struct EffectObj*);
 
 // D_8010B504
-void func_800B76A4(void);
-void func_800B7764(void);
-void func_800B7934(void);
-void func_800B7B18(void);
-void func_800B7CFC(void);
+extern void (*D_8010B504[])(struct EffectObj*);
+void func_800B76A4(struct EffectObj*);
+void func_800B7764(struct EffectObj*);
+void func_800B7934(struct EffectObj*);
+void func_800B7B18(struct EffectObj*);
+void func_800B7CFC(struct EffectObj*);
 
 // D_8010B62C
-void func_800B80A8(void);
-void func_800B8114(void);
-void func_800B8470(void);
+extern void (*D_8010B62C[])(struct EffectObj*);
+void func_800B80A8(struct EffectObj*);
+void func_800B8114(struct EffectObj*);
+void func_800B8470(struct EffectObj*);
 
 // D_8010B638
-void func_800B8518(void);
-void func_800B8554(void);
-void func_800B8610(void);
+extern void (*D_8010B638[])(struct EffectObj*);
+void func_800B8518(struct EffectObj*);
+void func_800B8554(struct EffectObj*);
+void func_800B8610(struct EffectObj*);
 
 // D_8010B6B8
-void func_800B89B4(void);
-void func_800B89CC(void);
-void func_800B8A9C(void);
+extern void (*D_8010B6B8[])(struct EffectObj*);
+void func_800B89B4(struct EffectObj*);
+void func_800B89CC(struct EffectObj*);
+void func_800B8A9C(struct EffectObj*);
 
 // D_8010B6D0
-void func_800B8B34(void);
-void func_800B8B6C(void);
+extern void (*D_8010B6D0[])(struct EffectObj*);
+void func_800B8B34(struct EffectObj*);
+void func_800B8B6C(struct EffectObj*);
 
 // D_8010B6D8
-void func_800B8BC0(void);
-void func_800B8C30(void);
-void func_800B8CA0(void);
-void func_800B8D10(void);
-void func_800B8D8C(void);
-void func_800B8DFC(void);
-void func_800B8E6C(void);
+extern void (*D_8010B6D8[])(struct EffectObj*);
+void func_800B8BC0(struct EffectObj*);
+void func_800B8C30(struct EffectObj*);
+void func_800B8CA0(struct EffectObj*);
+void func_800B8D10(struct EffectObj*);
+void func_800B8D8C(struct EffectObj*);
+void func_800B8DFC(struct EffectObj*);
+void func_800B8E6C(struct EffectObj*);
 
 // D_8010B6F4
-void func_800B8F98(void);
-void func_800B902C(void);
-void func_800B9070(void);
+extern void (*D_8010B6F4[])(struct EffectObj*);
+void func_800B8F98(struct EffectObj*);
+void func_800B902C(struct EffectObj*);
+void func_800B9070(struct EffectObj*);
 
 // D_8010B79C
-void func_800B913C(void);
-void func_800B91E0(void);
-void func_800B9310(void);
+extern void (*D_8010B79C[])(struct EffectObj*);
+void func_800B913C(struct EffectObj*);
+void func_800B91E0(struct EffectObj*);
+void func_800B9310(struct EffectObj*);
 
 // D_8010B7A8
-void func_800B96CC(void);
-void func_800B96E0(void);
-void func_800B97B0(void);
+extern void (*D_8010B7A8[])(struct EffectObj*);
+void func_800B96CC(struct EffectObj*);
+void func_800B96E0(struct EffectObj*);
+void func_800B97B0(struct EffectObj*);
 
 // D_8010B7B8
-void func_800B997C(void);
-void func_800B99B4(void);
+extern void (*D_8010B7B8[])(struct EffectObj*);
+void func_800B997C(struct EffectObj*);
+void func_800B99B4(struct EffectObj*);
 
 // D_8010B7C0
-void func_800B9A08(void);
-void func_800B9A78(void);
-void func_800B9AE8(void);
-void func_800B9B58(void);
+extern void (*D_8010B7C0[])(struct EffectObj*);
+void func_800B9A08(struct EffectObj*);
+void func_800B9A78(struct EffectObj*);
+void func_800B9AE8(struct EffectObj*);
+void func_800B9B58(struct EffectObj*);
 
 // D_8010B7D4
-void func_800B9C0C(void);
-void func_800B9C44(void);
+extern void (*D_8010B7D4[])(struct EffectObj*);
+void func_800B9C0C(struct EffectObj*);
+void func_800B9C44(struct EffectObj*);
 
 // D_8010B7DC
-void func_800B9C98(void);
-void func_800B9D08(void);
-void func_800B9D78(void);
-void func_800B9DDC(void);
+extern void (*D_8010B7DC[])(struct EffectObj*);
+void func_800B9C98(struct EffectObj*);
+void func_800B9D08(struct EffectObj*);
+void func_800B9D78(struct EffectObj*);
+void func_800B9DDC(struct EffectObj*);
 
 // D_8010BDF8
-void func_800B9F38(void);
-void func_800BA178(void);
-void func_800BA178(void);
-void func_800BA340(void);
-void func_800BA178(void);
-void func_800BA178(void);
+extern void (*D_8010BDF8[])(struct EffectObj*);
+void func_800B9F38(struct EffectObj*);
+void func_800BA178(struct EffectObj*);
+void func_800BA178(struct EffectObj*);
+void func_800BA340(struct EffectObj*);
+void func_800BA178(struct EffectObj*);
+void func_800BA178(struct EffectObj*);
 
 // D_8010BE10
-void func_800B9EC0(void);
-void func_800BA4E4(void);
-void func_800BA520(void);
+extern void (*D_8010BE10[])(struct EffectObj*);
+void func_800B9EC0(struct EffectObj*);
+void func_800BA4E4(struct EffectObj*);
+void func_800BA520(struct EffectObj*);
 
 // D_8010BE24
-void func_800BA5B8(void);
-void func_800BA5F0(void);
+extern void (*D_8010BE24[])(struct EffectObj*);
+void func_800BA5B8(struct EffectObj*);
+void func_800BA5F0(struct EffectObj*);
 
 // D_8010BE2C
-void func_800BA644(void);
-void func_800BA7C8(void);
-void func_800BA82C(void);
-void func_800BA8CC(void);
-void func_800BA948(void);
-void func_800BA9B8(void);
+extern void (*D_8010BE2C[])(struct EffectObj*);
+void func_800BA644(struct EffectObj*);
+void func_800BA7C8(struct EffectObj*);
+void func_800BA82C(struct EffectObj*);
+void func_800BA8CC(struct EffectObj*);
+void func_800BA948(struct EffectObj*);
+void func_800BA9B8(struct EffectObj*);
 
 // D_8010BE64
-void func_800BAA6C(void);
-void func_800BAAE0(void);
+extern void (*D_8010BE64[])(struct EffectObj*);
+void func_800BAA6C(struct EffectObj*);
+void func_800BAAE0(struct EffectObj*);
 
 // D_8010BE6C
-void func_800BAC58(void);
-void func_800BAD10(void);
-void func_800BAD44(void);
-void func_800BADD0(void);
-void func_800BAE5C(void);
+extern void (*D_8010BE6C[])(struct EffectObj*);
+void func_800BAC58(struct EffectObj*);
+void func_800BAD10(struct EffectObj*);
+void func_800BAD44(struct EffectObj*);
+void func_800BADD0(struct EffectObj*);
+void func_800BAE5C(struct EffectObj*);
 
 // D_8010BE80
-void func_800BABA8(void);
-void func_800BAE94(void);
-void func_800BAF04(void);
+extern void (*D_8010BE80[])(struct EffectObj*);
+void func_800BABA8(struct EffectObj*);
+void func_800BAE94(struct EffectObj*);
+void func_800BAF04(struct EffectObj*);
 
 // D_8010BE90
-void func_800BAF9C(void);
-void func_800BAFD4(void);
+extern void (*D_8010BE90[])(struct EffectObj*);
+void func_800BAF9C(struct EffectObj*);
+void func_800BAFD4(struct EffectObj*);
 
 // D_8010BE98
-void func_800BB028(void);
-void func_800BB098(void);
-void func_800BB108(void);
-void func_800BB178(void);
+extern void (*D_8010BE98[])(struct EffectObj*);
+void func_800BB028(struct EffectObj*);
+void func_800BB098(struct EffectObj*);
+void func_800BB108(struct EffectObj*);
+void func_800BB178(struct EffectObj*);
 
 // D_8010BEA8
-void func_800BB1F0(void);
-void func_800BB364(void);
-void func_800BB5F4(void);
-void func_800BB68C(void);
-void func_800BB750(void);
-void func_800BB85C(void);
-void func_800BB888(void);
-void func_800BB928(void);
+extern void (*D_8010BEA8[])(struct EffectObj*);
+void func_800BB1F0(struct EffectObj*);
+void func_800BB364(struct EffectObj*);
+void func_800BB5F4(struct EffectObj*);
+void func_800BB68C(struct EffectObj*);
+void func_800BB750(struct EffectObj*);
+void func_800BB85C(struct EffectObj*);
+void func_800BB888(struct EffectObj*);
+void func_800BB928(struct EffectObj*);
 
 // D_8010BEC8
 void func_800BB9F4(struct Unk21* arg0);
@@ -5016,99 +5051,118 @@ void func_800BBA24(struct Unk21* arg0);
 void func_800BBBF4(struct Unk21* arg0);
 
 // D_8010BED4
-void func_800BBC50(void);
-void func_800BBD24(void);
-void func_800BBD88(void);
-void func_800BBE84(void);
+extern void (*D_8010BED4[])(struct EffectObj*);
+void func_800BBC50(struct EffectObj*);
+void func_800BBD24(struct EffectObj*);
+void func_800BBD88(struct EffectObj*);
+void func_800BBE84(struct EffectObj*);
 
 // D_8010BEE4
-void func_800BBEA4(void);
-void func_800BBF34(void);
+extern void (*D_8010BEE4[])(struct EffectObj*);
+void func_800BBEA4(struct EffectObj*);
+void func_800BBF34(struct EffectObj*);
 
 // D_8010BF30
-void func_800BC180(void);
-void func_800BC210(void);
+extern void (*D_8010BF30[])(struct EffectObj*);
+void func_800BC180(struct EffectObj*);
+void func_800BC210(struct EffectObj*);
 
 // D_8010BF90
-void func_800BC554(void);
-void func_800BC568(void);
+extern void (*D_8010BF90[])(struct EffectObj*);
+void func_800BC554(struct EffectObj*);
+void func_800BC568(struct EffectObj*);
 
 // D_8010BF98
-void func_800BC784(void);
-void func_800BC92C(void);
-void func_800BCD84(void);
-void func_800BCE40(void);
+extern void (*D_8010BF98[])(struct EffectObj*);
+void func_800BC784(struct EffectObj*);
+void func_800BC92C(struct EffectObj*);
+void func_800BCD84(struct EffectObj*);
+void func_800BCE40(struct EffectObj*);
 
 // D_8010BFDC
-void func_800BCE84(void);
-void func_800BCEE4(void);
-void func_800BD01C(void);
+extern void (*D_8010BFDC[])(struct EffectObj*);
+void func_800BCE84(struct EffectObj*);
+void func_800BCEE4(struct EffectObj*);
+void func_800BD01C(struct EffectObj*);
 
 // D_8010C008
-void func_800BD1E4(void);
-void func_800BD23C(void);
-void func_800BD280(void);
-void func_800BD31C(void);
+extern void (*D_8010C008[])(struct EffectObj*);
+void func_800BD1E4(struct EffectObj*);
+void func_800BD23C(struct EffectObj*);
+void func_800BD280(struct EffectObj*);
+void func_800BD31C(struct EffectObj*);
 
 // D_8010C018
-void func_800BD3C0(void);
-void func_800BD478(void);
-void func_800BD4EC(void);
+extern void (*D_8010C018[])(struct EffectObj*);
+void func_800BD3C0(struct EffectObj*);
+void func_800BD478(struct EffectObj*);
+void func_800BD4EC(struct EffectObj*);
 
 // D_8010C024
-void func_800BD50C(void);
-void func_800BD5AC(void);
+extern void (*D_8010C024[])(struct EffectObj*);
+void func_800BD50C(struct EffectObj*);
+void func_800BD5AC(struct EffectObj*);
 
 // D_8010C048
-void func_800BD690(void);
-void func_800BD708(void);
-void func_800BD7B0(void);
-void func_800BD890(void);
-void func_800BD8C4(void);
-void func_800BD938(void);
-void func_800BDA2C(void);
+extern void (*D_8010C048[])(struct EffectObj*);
+void func_800BD690(struct EffectObj*);
+void func_800BD708(struct EffectObj*);
+void func_800BD7B0(struct EffectObj*);
+void func_800BD890(struct EffectObj*);
+void func_800BD8C4(struct EffectObj*);
+void func_800BD938(struct EffectObj*);
+void func_800BDA2C(struct EffectObj*);
 
 // D_8010C08C
-void func_800BDEA4(void);
-void func_800BDF20(void);
+extern void (*D_8010C08C[])(struct EffectObj*);
+void func_800BDEA4(struct EffectObj*);
+void func_800BDF20(struct EffectObj*);
 
 // D_8010C0D4
-void func_800BE074(void);
-void func_800BE0DC(void);
+extern void (*D_8010C0D4[])(struct EffectObj*);
+void func_800BE074(struct EffectObj*);
+void func_800BE0DC(struct EffectObj*);
 
 // D_8010C0F8
-void func_800BE1C0(void);
-void func_800BE214(void);
+extern void (*D_8010C0F8[])(struct EffectObj*);
+void func_800BE1C0(struct EffectObj*);
+void func_800BE214(struct EffectObj*);
 
 // D_8010C100
-void func_800BE30C(void);
-void func_800BE32C(void);
-void func_800BE364(void);
-void func_800BE434(void);
-void func_800BE4A8(void);
+extern void (*D_8010C100[])(struct EffectObj*);
+void func_800BE30C(struct EffectObj*);
+void func_800BE32C(struct EffectObj*);
+void func_800BE364(struct EffectObj*);
+void func_800BE434(struct EffectObj*);
+void func_800BE4A8(struct EffectObj*);
 
 // D_8010C114
-void func_800BE2C4(void);
-void func_800BE4D4(void);
-void func_800BE510(void);
+extern void (*D_8010C114[])(struct EffectObj*);
+void func_800BE2C4(struct EffectObj*);
+void func_800BE4D4(struct EffectObj*);
+void func_800BE510(struct EffectObj*);
 
 // D_8010C120
-void func_800BE598(void);
-void func_800BE5F4(void);
+extern void (*D_8010C120[])(struct EffectObj*);
+void func_800BE598(struct EffectObj*);
+void func_800BE5F4(struct EffectObj*);
 
 // D_8010C128
-void func_800BE714(void);
-void func_800BE730(void);
+extern void (*D_8010C128[])(struct EffectObj*);
+void func_800BE714(struct EffectObj*);
+void func_800BE730(struct EffectObj*);
 
 // D_8010C130
-void func_800BE57C(void);
-void func_800BE6D8(void);
-void func_800BE7C4(void);
+extern void (*D_8010C130[])(struct EffectObj*);
+void func_800BE57C(struct EffectObj*);
+void func_800BE6D8(struct EffectObj*);
+void func_800BE7C4(struct EffectObj*);
 
 // D_8010C13C
-void func_800BE878(void);
-void func_800BE8E4(void);
-void func_800BE960(void);
+extern void (*D_8010C13C[])(struct EffectObj*);
+void func_800BE878(struct EffectObj*);
+void func_800BE8E4(struct EffectObj*);
+void func_800BE960(struct EffectObj*);
 
 // D_8010C148
 void func_800BE9E8(void);

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -9342,13 +9342,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B55AC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B56D4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B56F4);
+void func_800B56F4(struct EffectObj* arg0)
+{
+    D_8010A798[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5730);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5798);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B58A0);
+void func_800B58A0(struct EffectObj* arg0)
+{
+    D_8010AFAC[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B58DC);
 
@@ -9371,10 +9377,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5C60);
 void func_800B5CC4(struct EffectObj* arg0)
 {
     if (arg0->state == 0) {
-        func_800B5D04();
+        func_800B5D04(arg0);
         return;
     }
-    func_800B5E2C();
+    func_800B5E2C(arg0);
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5D04);
@@ -9387,7 +9393,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5EEC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B6060);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B6080);
+void func_800B6080(struct EffectObj* arg0)
+{
+    D_8010B444[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B60BC);
 
@@ -9397,7 +9406,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B64BC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B6660);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B6A0C);
+void func_800B6A0C(struct EffectObj* arg0)
+{
+    D_8010B45C[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B6A48);
 

--- a/src/main/A7878.c
+++ b/src/main/A7878.c
@@ -1,6 +1,9 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B7078);
+void func_800B7078(struct EffectObj* arg0)
+{
+    D_8010B4D8[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B70B4);
 
@@ -36,13 +39,16 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B74C0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B74EC);
 
-void func_800B7520(void)
+void func_800B7520(struct EffectObj* arg0)
 {
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B7528);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B75C8);
+void func_800B75C8(struct EffectObj* arg0)
+{
+    D_8010B4F8[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B7604);
 
@@ -68,7 +74,10 @@ void func_800B8064(struct EffectObj* arg0)
 {
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B806C);
+void func_800B806C(struct EffectObj* arg0)
+{
+    D_8010B62C[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B80A8);
 
@@ -78,7 +87,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8470);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8490);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B84DC);
+void func_800B84DC(struct EffectObj* arg0)
+{
+    D_8010B638[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8518);
 
@@ -98,9 +110,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B89CC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8A9C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8ABC);
+void func_800B8ABC(struct EffectObj* arg0)
+{
+    D_8010B6B8[arg0->state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8AF8);
+void func_800B8AF8(struct EffectObj* arg0)
+{
+    D_8010B6D0[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8B34);
 
@@ -142,13 +160,16 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8E3C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8E5C);
 
-void func_800B8E6C(void)
+void func_800B8E6C(struct EffectObj* arg0)
 {
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8E74);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8F5C);
+void func_800B8F5C(struct EffectObj* arg0)
+{
+    D_8010B6F4[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B8F98);
 
@@ -156,7 +177,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B902C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9070);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9100);
+void func_800B9100(struct EffectObj* arg0)
+{
+    D_8010B79C[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B913C);
 
@@ -168,7 +192,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9354);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B94B8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9690);
+void func_800B9690(struct EffectObj* arg0)
+{
+    D_8010B7A8[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B96CC);
 
@@ -178,7 +205,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B97B0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B97D0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9940);
+void func_800B9940(struct EffectObj* arg0)
+{
+    D_8010B7B8[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B997C);
 
@@ -202,13 +232,16 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9B28);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9B48);
 
-void func_800B9B58(void)
+void func_800B9B58(struct EffectObj* arg0)
 {
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9B60);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9BD0);
+void func_800B9BD0(struct EffectObj* arg0)
+{
+    D_8010B7D4[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9C0C);
 
@@ -232,7 +265,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9DB8);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800B9DCC);
 
-void func_800B9DDC(void)
+void func_800B9DDC(struct EffectObj* arg0)
 {
 }
 
@@ -252,9 +285,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA4E4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA520);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA540);
+void func_800BA540(struct EffectObj* arg0)
+{
+    D_8010BE10[arg0->state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA57C);
+void func_800BA57C(struct EffectObj* arg0)
+{
+    D_8010BE24[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA5B8);
 
@@ -290,13 +329,16 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA988);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA9A8);
 
-void func_800BA9B8(void)
+void func_800BA9B8(struct EffectObj* arg0)
 {
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BA9C0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAA30);
+void func_800BAA30(struct EffectObj* arg0)
+{
+    D_8010BE64[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAA6C);
 
@@ -320,9 +362,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAE94);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAF04);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAF24);
+void func_800BAF24(struct EffectObj* arg0)
+{
+    D_8010BE80[arg0->state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAF60);
+void func_800BAF60(struct EffectObj* arg0)
+{
+    D_8010BE90[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BAF9C);
 
@@ -346,7 +394,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BB148);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BB168);
 
-void func_800BB178(void)
+void func_800BB178(struct EffectObj* arg0)
 {
 }
 
@@ -374,7 +422,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BB888);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BB928);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BB97C);
+void func_800BB97C(struct EffectObj* arg0)
+{
+    D_8010BEA8[arg0->state](arg0);
+}
 
 // megaman never teleports in if nopped out
 // asm(".rept 13 ; nop ; .endr");
@@ -398,7 +449,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBA24);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBBF4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBC14);
+void func_800BBC14(struct EffectObj* arg0)
+{
+    D_8010BED4[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBC50);
 
@@ -414,7 +468,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBF34);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BBFCC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC144);
+void func_800BC144(struct EffectObj* arg0)
+{
+    D_8010BF30[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC180);
 
@@ -428,9 +485,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC370);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC3E8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC4D8);
+void func_800BC4D8(struct EffectObj* arg0)
+{
+    if (arg0->state == 0) {
+        func_800BC370(arg0);
+    } else {
+        func_800BC3E8(arg0);
+    }
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC518);
+void func_800BC518(struct EffectObj* arg0)
+{
+    D_8010BF90[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC554);
 
@@ -442,7 +509,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC63C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC6FC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC748);
+void func_800BC748(struct EffectObj* arg0)
+{
+    D_8010BF98[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC784);
 
@@ -450,17 +520,20 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BC92C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BCD84);
 
-void func_800BCE40(void)
+void func_800BCE40(struct EffectObj* arg0)
 {
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BCE48);
+void func_800BCE48(struct EffectObj* arg0)
+{
+    D_8010BFDC[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BCE84);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BCEE4);
 
-void func_800BD01C(void)
+void func_800BD01C(struct EffectObj* arg0)
 {
 }
 
@@ -468,7 +541,14 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD024);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD080);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD1A4);
+void func_800BD1A4(struct EffectObj* arg0)
+{
+    if (arg0->state == 0) {
+        func_800BD024(arg0);
+    } else {
+        func_800BD080(arg0);
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD1E4);
 
@@ -478,9 +558,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD280);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD31C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD348);
+void func_800BD348(struct EffectObj* arg0)
+{
+    D_8010C008[arg0->state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD384);
+void func_800BD384(struct EffectObj* arg0)
+{
+    D_8010C018[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD3C0);
 
@@ -492,7 +578,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD50C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD5AC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD654);
+void func_800BD654(struct EffectObj* arg0)
+{
+    D_8010C048[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BD690);
 
@@ -520,7 +609,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDD08);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDDE8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDE68);
+void func_800BDE68(struct EffectObj* arg0)
+{
+    D_8010C08C[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDEA4);
 
@@ -530,7 +622,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDF40);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BDFC8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE038);
+void func_800BE038(struct EffectObj* arg0)
+{
+    D_8010C0D4[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE074);
 
@@ -538,7 +633,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE0DC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE0FC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE184);
+void func_800BE184(struct EffectObj* arg0)
+{
+    D_8010C0F8[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE1C0);
 
@@ -562,7 +660,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE4D4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE510);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE540);
+void func_800BE540(struct EffectObj* arg0)
+{
+    D_8010C114[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE57C);
 
@@ -578,9 +679,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE730);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE7C4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE800);
+void func_800BE800(struct EffectObj* arg0)
+{
+    D_8010C130[arg0->state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE83C);
+void func_800BE83C(struct EffectObj* arg0)
+{
+    D_8010C13C[arg0->state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE878);
 

--- a/src/main/search_light_maker.c
+++ b/src/main/search_light_maker.c
@@ -5,7 +5,7 @@
 void func_800B6B18(struct EffectObj* arg0)
 {
     // asm(".rept 13 ; nop ; .endr");
-    D_8010B4C4[arg0->state]();
+    D_8010B4C4[arg0->state](arg0);
 }
 
 // D_8010B4C4 state 0


### PR DESCRIPTION
These mostly follow the same pattern. It wouldn't be too much more work to extract the data as well, or rename them to follow a consistent pattern, if necessary.