### PR TITLE
Decompile func_8002A728 and func_8002A6FC

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -198,9 +198,16 @@ struct PlayerObj {
     s8 unkC0;
     s8 padC0[2];
     s8 unkC3;
-    s8 padC3[1];
+    s8 unkC4;
     s8 unkC5;
-}; // size ?
+    s8 padC6[0xD7 - 0xC6];
+    s8 unkD7;
+    s8 : 8;
+    s8 unkD9;
+    s8 padDA[0xE0 - 0xDA];
+    s8 unkE0;
+    s8 padE1[0xE4 - 0xE1];
+}; // size 0xE4
 
 struct Unk_unk68 {
     s8 unk0;

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1560,9 +1560,25 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002A41C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002A484);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002A6FC);
+void func_8002A6FC()
+{
+    s8 fill = 0;
+    s8* a0 = (u8*)&D_801721C0;
+    s32 v1 = 0x64 - 1;
+    do {
+        *a0++ = fill;
+    } while (v1-- != 0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002A728);
+void func_8002A728(struct PlayerObj* arg0)
+{
+    s8 fill = 0;
+    s32 v1 = sizeof(struct PlayerObj) - 1;
+    s8* a0 = (u8*)arg0;
+    do {
+        *a0++ = fill;
+    } while (v1-- != 0);
+}
 
 void func_8002A74C()
 {


### PR DESCRIPTION
Continues the work started in https://github.com/sozud/mmx4/pull/85. Decompiles two more reset functions and confirms the size of the `PlayerObj` struct.