### PR TITLE
Enable asm differ

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tools/psximager"]
 	path = tools/psximager
 	url = https://github.com/sozud/psximager.git
+[submodule "tools/asm-differ"]
+	path = tools/asm-differ
+	url = https://github.com/simonlindholm/asm-differ.git

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -1,0 +1,3 @@
+def apply(config, args):
+    config["mapfile"] = "build/us/main.map"
+    config["objdump_executable"] = "mipsel-linux-gnu-objdump"

--- a/expected.sh
+++ b/expected.sh
@@ -2,3 +2,5 @@ mkdir -p expected/us
 cp build/us/main.o expected/us/main.o
 cp build/us/main.bin expected/us/main.bin
 cp build/us/main.map expected/us/main.map
+mkdir -p expected/build/us
+cp -r build/us/src expected/build/us/src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
+colorama
 crunch64
+levenshtein
 n64img
 ninja
 pygfxd
 spimdisasm>=1.28.1,<2.0.0
 splat64
 tabulate
+watchdog


### PR DESCRIPTION
Might be worth pulling this one locally to confirm I got all the requirements...

I had to `sudo ln -s /usr/bin/mipsel-linux-gnu-objdump /usr/bin/mips-linux-gnu-objdump` as a hack

All said, `python3 tools/asm-differ/diff.py func_80024E70 -o` should now work

<img width="774" alt="image" src="https://github.com/user-attachments/assets/3171a3fd-43ca-422e-b822-fab741098f3c">