### PR TITLE
func_800CB27C

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -426,9 +426,9 @@ struct ReadyTextExt {
     struct MiscUnk50* unk50;
     u16 unk54;
     s8 pad54[2];
-    u16 unk58;
+    u16 palette_pos;
     s8 pad58[2];
-    u16 unk5C;
+    u16 palette_cycle_done;
 };
 
 struct TitleLogoExt {

--- a/include/common.h
+++ b/include/common.h
@@ -417,12 +417,49 @@ struct LayerObj {
     u8 pad[0x2F];
 }; // size 0x30
 
+struct MiscUnk50 {
+    u8 pad[0x16];
+    u8 unk16;
+};
+
+struct ReadyTextExt {
+    struct MiscUnk50* unk50;
+    u16 unk54;
+    s8 pad54[2];
+    u16 unk58;
+    s8 pad58[2];
+    u16 unk5C;
+};
+
+struct TitleLogoExt {
+    s32 unk50;
+    s8 palette_shift_speed;
+    u8 palette_shift_value; // 0x55
+    s8 unk56;
+    u8 unk57;
+    s32 palette1; // 0x58
+    s32 palette2; // 0x5C
+};
+
+struct SelectACharacterExt {
+    s8 pad50[5];
+    u8 blast_timer; // 0x55
+    s8 unk56;
+    u8 unk57;
+};
+
+union MiscExt {
+    struct ReadyTextExt ready_text;
+    struct TitleLogoExt title_logo;
+    struct SelectACharacterExt sel_char;
+};
+
 struct MiscObj {
     struct BaseObj base;
     s32 unk18;
     s32 unk1C;
     f32 x_vel; // 0x20
-    s32 unk24;
+    f32 y_vel;
     s32 unk28;
     s32 unk2C;
     u8 pad30[0x8];
@@ -434,13 +471,7 @@ struct MiscObj {
     s8 unk45;
     s8 unk46;
     s8 pad47[6];
-    s32 unk50;
-    s8 palette_shift_speed;
-    u8 palette_shift_value; // 0x55
-    s8 unk56;
-    u8 unk57;
-    s32 palette1; // 0x58
-    s32 palette2; // 0x5C
+    union MiscExt ext;
 }; // size 0x60
 
 struct BazObj {

--- a/src/main/A7878.c
+++ b/src/main/A7878.c
@@ -1341,8 +1341,39 @@ void func_800CB22C(struct Unk* arg0)
     is_on_screen(arg0);
 }
 
+extern u8 D_8010E6B0[];
+
 // ReadyText State 0
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800CB27C);
+void func_800CB27C(struct MiscObj* arg0)
+{
+    if (arg0->ext.ready_text.unk50->unk16 != 0) {
+        func_800CB5B4(arg0, NULL);
+        arg0->base.unk5 = 1;
+        arg0->ext.ready_text.unk54 = 8;
+        if (arg0->base.unk2 != 0) {
+            arg0->unk42 = 0x7840;
+            arg0->x_vel.val = FIXED(.25);
+            arg0->y_vel.val = FIXED(-.5);
+            return;
+        }
+        arg0->x_vel.val = FIXED(-.25);
+        arg0->y_vel.val = FIXED(.5);
+        func_8001540C(0, 0xA, 0);
+        return;
+    }
+    if ((arg0->base.unk2 == 0) && (arg0->ext.ready_text.unk5C == 0)) {
+        if (arg0->ext.ready_text.unk54 != 0) {
+            arg0->ext.ready_text.unk54--;
+            return;
+        }
+        func_800CB5B4(arg0, D_8010E6B0[arg0->ext.ready_text.unk58]);
+        arg0->ext.ready_text.unk58++;
+        if (arg0->ext.ready_text.unk58 >= 14) {
+            arg0->ext.ready_text.unk58 = 0;
+            arg0->ext.ready_text.unk5C = 1;
+        }
+    }
+}
 
 // ReadyText State 1
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800CB394);

--- a/src/main/A7878.c
+++ b/src/main/A7878.c
@@ -1353,24 +1353,25 @@ void func_800CB27C(struct MiscObj* arg0)
         if (arg0->base.unk2 != 0) {
             arg0->unk42 = 0x7840;
             arg0->x_vel.val = FIXED(.25);
-            arg0->y_vel.val = FIXED(-.5);
+            arg0->y_vel.val = FIXED(-.5); // set y velocity of shadow behind "READY"
             return;
         }
         arg0->x_vel.val = FIXED(-.25);
-        arg0->y_vel.val = FIXED(.5);
+        arg0->y_vel.val = FIXED(.5); // set y velocity of blue "READY"
         func_8001540C(0, 0xA, 0);
         return;
     }
-    if ((arg0->base.unk2 == 0) && (arg0->ext.ready_text.unk5C == 0)) {
+    if ((arg0->base.unk2 == 0) && (arg0->ext.ready_text.palette_cycle_done == 0)) {
         if (arg0->ext.ready_text.unk54 != 0) {
             arg0->ext.ready_text.unk54--;
             return;
         }
-        func_800CB5B4(arg0, D_8010E6B0[arg0->ext.ready_text.unk58]);
-        arg0->ext.ready_text.unk58++;
-        if (arg0->ext.ready_text.unk58 >= 14) {
-            arg0->ext.ready_text.unk58 = 0;
-            arg0->ext.ready_text.unk5C = 1;
+        // cycle palette when "READY" first appears
+        func_800CB5B4(arg0, D_8010E6B0[arg0->ext.ready_text.palette_pos]);
+        arg0->ext.ready_text.palette_pos++;
+        if (arg0->ext.ready_text.palette_pos >= 14) {
+            arg0->ext.ready_text.palette_pos = 0;
+            arg0->ext.ready_text.palette_cycle_done = 1;
         }
     }
 }

--- a/src/main/BDF8C.c
+++ b/src/main/BDF8C.c
@@ -21,12 +21,12 @@ void func_800CDB10(struct MiscObj* arg0)
     func_80015DC8();
     // transition "MEGAMAN" to white before full logo appears
     if (arg0->unk46 == 0) {
-        arg0->palette2 = (s32)(*(s32*)SP_PALETTE_ADDR + 0x200);
-        arg0->palette1 = (s32) * (s32*)0x1F800030;
+        arg0->ext.title_logo.palette2 = (s32)(*(s32*)SP_PALETTE_ADDR + 0x200);
+        arg0->ext.title_logo.palette1 = (s32) * (s32*)0x1F800030;
         // interval to shift on
-        arg0->palette_shift_speed = 2;
+        arg0->ext.title_logo.palette_shift_speed = 2;
         // how much to shift each step
-        arg0->palette_shift_value = 0xF;
+        arg0->ext.title_logo.palette_shift_value = 0xF;
         arg0->base.state++;
     }
     is_on_screen(arg0);

--- a/src/main/select_a_character.c
+++ b/src/main/select_a_character.c
@@ -154,11 +154,11 @@ void func_800CD0A4(struct MiscObj* arg0)
 void func_800CD110(struct MiscObj* arg0)
 {
     func_80015DC8();
-    if (engine_obj.unk43 != arg0->unk57) {
+    if (engine_obj.unk43 != arg0->ext.sel_char.unk57) {
         arg0->base.unk6 = 0;
         func_8001540C(5, 0, NULL);
     }
-    arg0->unk57 = engine_obj.unk43;
+    arg0->ext.sel_char.unk57 = engine_obj.unk43;
 }
 
 // D_8010EBB4 state 6
@@ -183,7 +183,7 @@ void func_800CD1E8(struct MiscObj* arg0)
         return;
     }
     if (engine_obj.unk43 == (arg0->base.unk2 - 7)) {
-        if (arg0->palette_shift_value == 0) {
+        if (arg0->ext.sel_char.blast_timer == 0) {
             arg0->base.unk6++;
             func_80015D60(arg0, 1);
             if (arg0->base.unk2 == 7) {
@@ -199,7 +199,7 @@ void func_800CD1E8(struct MiscObj* arg0)
                 }
             }
         } else {
-            arg0->palette_shift_value--;
+            arg0->ext.sel_char.blast_timer--;
         }
     }
 }
@@ -213,7 +213,7 @@ void func_800CD390(struct MiscObj* arg0)
     D_8010EBA8[arg0->base.unk6]();
     if ((engine_obj.unk43 != (arg0->base.unk2 - 7)) && (arg0->unk46 == 0)) {
         arg0->base.unk6 = 0;
-        arg0->palette_shift_value = 0;
+        arg0->ext.sel_char.blast_timer = 0;
     }
 }
 


### PR DESCRIPTION
It does seem like objects have extensions, it's possible that originally each u32 was a union where you could have 
```
u8 a,b,c,d;
u16 a,b;
u32 a
```
But not sure yet, we can continue figuring it out as we go