### PR TITLE
Integrate all remaining trivial visual update funcs

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -248,7 +248,9 @@ struct PlayerObj {
     s8 unkD7;
     s8 : 8;
     s8 unkD9;
-    s8 padDA[0xE0 - 0xDA];
+    s8 padDA[0xDE - 0xDA];
+    s8 unkDE;
+    s8 : 8;
     s8 unkE0;
     s8 padE1[0xE4 - 0xE1];
 }; // size 0xE4
@@ -261,11 +263,11 @@ struct Unk_unk68 {
 };
 
 struct VisualObj {
-    s8 active;
-    s8 : 8;
-    s8 : 8;
-    s8 unk3;
-    u8 pad4[0x70 - 0x4];
+    struct BaseObj base;
+    s8 pad18[0x50 - 0x18];
+    s32 unk50;
+    s32 unk54;
+    u8 pa5A[0x70 - 0x5A];
 }; // size 0x70
 
 struct ShotObj {
@@ -383,11 +385,8 @@ struct UnkObj {
 }; // size 0x60
 
 struct ItemObj {
-    s8 active;
-    s8 : 8;
-    s8 : 8;
-    s8 unk3;
-    s8 pad4[0x50 - 0x4];
+    struct BaseObj base;
+    s8 pad18[0x50 - 0x18];
     s32 unk50;
     s32 unk54;
     s8 pad58[0x61 - 0x58];

--- a/include/func_tables.h
+++ b/include/func_tables.h
@@ -378,46 +378,46 @@ void func_800AE3F4(struct ShotObj*);
 void func_800AE65C(struct ShotObj*);
 
 // D_800F27BC (vis_object_update_funcs)
-void func_800AEAC0(void);
-void func_800AED18(void);
-void func_800AEED8(void);
-void func_800AF6A0(void);
-void func_800AFB50(void);
-void func_800AFC9C(void);
-void func_800AFF78(void);
-void func_800AF22C(void);
-void func_800B0890(void);
-void func_800B1354(void);
-void func_800B14E8(void);
-void func_800B17CC(void);
-void func_800B19BC(void);
-void func_800B1AF8(void);
-void func_800B1C5C(void);
-void func_800B1D6C(void);
-void func_800B1EA4(void);
-void func_800B2090(void);
-void func_800B2544(void);
-void func_800B2698(void);
-void func_800B2D48(void);
-void func_800B3020(void);
-void func_800B3074(void);
-void func_800B357C(void);
-void func_800B35B8(void);
-void func_800B3E40(void);
-void func_800B28CC(void);
-void func_800B2A3C(void);
-void func_800B3E7C(void);
-void func_800B41CC(void);
-void func_800B4610(void);
-void func_800B4B64(void);
-void func_800B5534(void);
-void func_800B2AD0(void);
-void func_800B5570(void);
-void func_800C6B84(void);
-void func_800C6C2C(void);
-void func_800C6CE4(void);
-void func_800C6EDC(void);
-void func_80098338(void);
+void func_800AEAC0(struct VisualObj*);
+void func_800AED18(struct VisualObj*);
+void func_800AEED8(struct VisualObj*);
+void func_800AF6A0(struct VisualObj*);
+void func_800AFB50(struct VisualObj*);
+void func_800AFC9C(struct VisualObj*);
+void func_800AFF78(struct VisualObj*);
+void func_800AF22C(struct VisualObj*);
+void func_800B0890(struct VisualObj*);
+void func_800B1354(struct VisualObj*);
+void func_800B14E8(struct VisualObj*);
+void func_800B17CC(struct VisualObj*);
+void func_800B19BC(struct VisualObj*);
+void func_800B1AF8(struct VisualObj*);
+void func_800B1C5C(struct VisualObj*);
+void func_800B1D6C(struct VisualObj*);
+void func_800B1EA4(struct VisualObj*);
+void func_800B2090(struct VisualObj*);
+void func_800B2544(struct VisualObj*);
+void func_800B2698(struct VisualObj*);
+void func_800B2D48(struct VisualObj*);
+void func_800B3020(struct VisualObj*);
+void func_800B3074(struct VisualObj*);
+void func_800B357C(struct VisualObj*);
+void func_800B35B8(struct VisualObj*);
+void func_800B3E40(struct VisualObj*);
+void func_800B28CC(struct VisualObj*);
+void func_800B2A3C(struct VisualObj*);
+void func_800B3E7C(struct VisualObj*);
+void func_800B41CC(struct VisualObj*);
+void func_800B4610(struct VisualObj*);
+void func_800B4B64(struct VisualObj*);
+void func_800B5534(struct VisualObj*);
+void func_800B2AD0(struct VisualObj*);
+void func_800B5570(struct VisualObj*);
+void func_800C6B84(struct VisualObj*);
+void func_800C6C2C(struct VisualObj*);
+void func_800C6CE4(struct VisualObj*);
+void func_800C6EDC(struct VisualObj*);
+void func_80098338(struct VisualObj*);
 
 // D_800F285C (effect_object_update_funcs)
 void func_800B56F4(struct EffectObj* arg0);
@@ -4773,9 +4773,10 @@ void func_800AE95C(void);
 void func_800AE9D8(void);
 
 // D_8010A1A0
-void func_800AEB1C(void);
-void func_800AEBA8(void);
-void func_800AEC48(void);
+extern void (*D_8010A1A0[])(struct VisualObj*, struct PlayerObj*);
+void func_800AEB1C(struct VisualObj*, struct PlayerObj*);
+void func_800AEBA8(struct VisualObj*, struct PlayerObj*);
+void func_800AEC48(struct VisualObj*, struct PlayerObj*);
 
 // D_8010A1C8
 void func_800AF488(void);
@@ -4799,84 +4800,99 @@ void func_800B06AC(void);
 void func_800B0804(void);
 
 // D_8010A430
-void func_800B08CC(void);
-void func_800B0B48(void);
-void func_800B0C78(void);
-void func_800B0C98(void);
+extern void (*D_8010A430[])(struct VisualObj*);
+void func_800B08CC(struct VisualObj*);
+void func_800B0B48(struct VisualObj*);
+void func_800B0C78(struct VisualObj*);
+void func_800B0C98(struct VisualObj*);
 
 // D_8010A4CC
-void func_800B1524(void);
-void func_800B158C(void);
-void func_800B16B0(void);
-void func_800B1758(void);
-void func_800B17AC(void);
+extern void (*D_8010A4CC[])(struct VisualObj*);
+void func_800B1524(struct VisualObj*);
+void func_800B158C(struct VisualObj*);
+void func_800B16B0(struct VisualObj*);
+void func_800B1758(struct VisualObj*);
+void func_800B17AC(struct VisualObj*);
 
 // D_8010A4E0
-void func_800B1808(void);
-void func_800B1864(void);
-void func_800B199C(void);
+extern void (*D_8010A4E0[])(struct VisualObj*);
+void func_800B1808(struct VisualObj*);
+void func_800B1864(struct VisualObj*);
+void func_800B199C(struct VisualObj*);
 
 // D_8010A4EC
-void func_800B19F8(void);
-void func_800B1A48(void);
-void func_800B1AD8(void);
+extern void (*D_8010A4EC[])(struct VisualObj*);
+void func_800B19F8(struct VisualObj*);
+void func_800B1A48(struct VisualObj*);
+void func_800B1AD8(struct VisualObj*);
 
 // D_8010A520
-void func_800B1B34(void);
-void func_800B1B74(void);
-void func_800B1C3C(void);
+extern void (*D_8010A520[])(struct VisualObj*);
+void func_800B1B34(struct VisualObj*);
+void func_800B1B74(struct VisualObj*);
+void func_800B1C3C(struct VisualObj*);
 
 // D_8010A52C
-void func_800B1C98(void);
-void func_800B1CF4(void);
-void func_800B1D4C(void);
+extern void (*D_8010A52C[])(struct VisualObj*);
+void func_800B1C98(struct VisualObj*);
+void func_800B1CF4(struct VisualObj*);
+void func_800B1D4C(struct VisualObj*);
 
 // D_8010A538
-void func_800B1DA8(void);
-void func_800B1DE4(void);
-void func_800B1E84(void);
+extern void (*D_8010A538[])(struct VisualObj*);
+void func_800B1DA8(struct VisualObj*);
+void func_800B1DE4(struct VisualObj*);
+void func_800B1E84(struct VisualObj*);
 
 // D_8010A544
-void func_800B1EE0(void);
-void func_800B1F78(void);
-void func_800B2070(void);
+extern void (*D_8010A544[])(struct VisualObj*);
+void func_800B1EE0(struct VisualObj*);
+void func_800B1F78(struct VisualObj*);
+void func_800B2070(struct VisualObj*);
 
 // D_8010A570
-void func_800B20CC(void);
-void func_800B2200(void);
-void func_800B2444(void);
+extern void (*D_8010A570[])(struct VisualObj*);
+void func_800B20CC(struct VisualObj*);
+void func_800B2200(struct VisualObj*);
+void func_800B2444(struct VisualObj*);
 
 // D_8010A57C
 void func_800B22B4(void);
 void func_800B23DC(void);
 
 // D_8010A5B0
-void func_800B2D84(void);
-void func_800B2DD0(void);
+extern void (*D_8010A5B0[])(struct VisualObj*);
+void func_800B2D84(struct VisualObj*);
+void func_800B2DD0(struct VisualObj*);
 
 // D_8010A5C8
-void func_800B2E98(void);
-void func_800B2F60(void);
-void func_800B3000(void);
+extern void (*D_8010A5C8[])(struct VisualObj*);
+void func_800B2E98(struct VisualObj*);
+void func_800B2F60(struct VisualObj*);
+void func_800B3000(struct VisualObj*);
 
 // D_8010A5D4
-void func_800B30B0(void);
-void func_800B3100(void);
-void func_800B320C(void);
+extern void (*D_8010A5D4[])(struct VisualObj*);
+void func_800B30B0(struct VisualObj*);
+void func_800B3100(struct VisualObj*);
+void func_800B320C(struct VisualObj*);
 
 // D_8010A5E4
-void func_800B3358(void);
-void func_800B3444(void);
-void func_800B34EC(void);
+extern void (*D_8010A5E4[])(struct VisualObj*);
+void func_800B3358(struct VisualObj*);
+void func_800B3444(struct VisualObj*);
+void func_800B34EC(struct VisualObj*);
 
 // D_8010A5F0
-void func_800B322C(void);
-void func_800B3508(void);
-void func_800B355C(void);
+extern void (*D_8010A5F0[])(struct VisualObj*);
+void func_800B322C(struct VisualObj*);
+void func_800B3508(struct VisualObj*);
+void func_800B355C(struct VisualObj*);
 
 // D_8010A64C
-void func_800B35F4(void);
-void func_800B36F0(void);
+extern void (*D_8010A64C[])(struct VisualObj*);
+void func_800B35F4(struct VisualObj*);
+void func_800B36F0(struct VisualObj*);
 
 // D_8010A654
 void func_800B372C(void);
@@ -4907,19 +4923,22 @@ void func_800B3C90(void);
 void func_800B3CCC(void);
 
 // D_8010A694
-void func_800B3D3C(void);
-void func_800B3DE8(void);
-void func_800B3E20(void);
+extern void (*D_8010A694[])(struct VisualObj*);
+void func_800B3D3C(struct VisualObj*);
+void func_800B3DE8(struct VisualObj*);
+void func_800B3E20(struct VisualObj*);
 
 // D_8010A6A0
-void func_800B3EB8(void);
-void func_800B3FD4(void);
-void func_800B41AC(void);
+extern void (*D_8010A6A0[])(struct VisualObj*);
+void func_800B3EB8(struct VisualObj*);
+void func_800B3FD4(struct VisualObj*);
+void func_800B41AC(struct VisualObj*);
 
 // D_8010A6AC
-void func_800B4208(void);
-void func_800B4598(void);
-void func_800B4578(void);
+extern void (*D_8010A6AC[])(struct VisualObj*);
+void func_800B4208(struct VisualObj*);
+void func_800B4598(struct VisualObj*);
+void func_800B4578(struct VisualObj*);
 
 // D_8010A6B8
 void func_800B4274(void);
@@ -4928,9 +4947,10 @@ void func_800B4480(void);
 void func_800B4558(void);
 
 // D_8010A6C8
-void func_800B464C(void);
-void func_800B46E8(void);
-void func_800B46C8(void);
+extern void (*D_8010A6C8[])(struct VisualObj*);
+void func_800B464C(struct VisualObj*);
+void func_800B46E8(struct VisualObj*);
+void func_800B46C8(struct VisualObj*);
 
 // D_8010A6D4
 void func_800B4754(void);
@@ -4955,10 +4975,11 @@ void func_800B4AA8(void);
 void func_800B4B0C(void);
 
 // D_8010A704
-void func_800B4BA0(void);
-void func_800B4CC8(void);
-void func_800B4D00(void);
-void func_800B4E14(void);
+extern void (*D_8010A704[])(struct VisualObj*);
+void func_800B4BA0(struct VisualObj*);
+void func_800B4CC8(struct VisualObj*);
+void func_800B4D00(struct VisualObj*);
+void func_800B4E14(struct VisualObj*);
 
 // D_8010A760
 void func_800B51E0(void);
@@ -4974,13 +4995,15 @@ void func_800B52D8(void);
 void func_800B5448(void);
 
 // D_8010A784
-void func_800B4E34(void);
-void func_800B54B0(void);
-void func_800B54EC(void);
+extern void (*D_8010A784[])(struct VisualObj*);
+void func_800B4E34(struct VisualObj*);
+void func_800B54B0(struct VisualObj*);
+void func_800B54EC(struct VisualObj*);
 
 // D_8010A790
-void func_800B55AC(void);
-void func_800B56D4(void);
+extern void (*D_8010A790[])(struct VisualObj*);
+void func_800B55AC(struct VisualObj*);
+void func_800B56D4(struct VisualObj*);
 
 // D_8010A798
 extern void (*D_8010A798[])(struct EffectObj*);

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1419,13 +1419,13 @@ void init_objects(void)
     }
 
     for (var_s0_5 = &visual_objects[0]; var_s0_5 < &visual_objects[COUNT(visual_objects)]; var_s0_5++) {
-        if (var_s0_5->unk3 != 0) {
+        if (var_s0_5->base.on_screen != 0) {
             func_80024334(var_s0_5);
         }
     }
 
     for (var_s0_6 = &item_objects[0]; var_s0_6 < &item_objects[COUNT(item_objects)]; var_s0_6++) {
-        if (var_s0_6->unk3 != 0) {
+        if (var_s0_6->base.on_screen != 0) {
             func_80024334(var_s0_6);
         }
     }
@@ -2213,7 +2213,7 @@ struct VisualObj* find_free_visual_obj()
 {
     struct VisualObj* current;
     for (current = &visual_objects[0]; current < &visual_objects[0x20]; current++) {
-        if (current->active == NULL) {
+        if (current->base.active == NULL) {
             return current;
         }
     }
@@ -2236,7 +2236,7 @@ struct ItemObj* find_free_item_obj()
 {
     struct ItemObj* current;
     for (current = &item_objects[0]; current < &item_objects[0x20]; current++) {
-        if (!current->active) {
+        if (!current->base.active) {
             current->unk50 = 0;
             current->unk54 = 0;
             current->unk68 = 0;
@@ -10035,7 +10035,14 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEA58);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEAA0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEAC0);
+void func_800AEAC0(struct VisualObj* arg0)
+{
+    struct PlayerObj* var_a1 = &g_Entity;
+    if (g_Player.unkDE == 0) {
+        var_a1 = (struct PlayerObj*)(&g_Player.unkDE - 0xDE);
+    }
+    D_8010A1A0[arg0->base.state](arg0, var_a1);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEB1C);
 
@@ -10049,7 +10056,14 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AED18);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEE5C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEED8);
+void func_800AEED8(struct VisualObj* arg0)
+{
+    if (arg0->base.state == 0) {
+        func_800AEF18(arg0);
+    } else {
+        func_800AF02C(arg0);
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEF18);
 
@@ -10061,7 +10075,18 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF15C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF1AC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF22C);
+void func_800AF22C(struct VisualObj* arg0)
+{
+    struct PlayerObj* var_a1 = &g_Entity;
+    if (!(arg0->base.unk2 & 2)) {
+        var_a1 = &g_Player;
+    }
+    if (arg0->base.state == 0) {
+        func_800AF28C(arg0, var_a1);
+    } else {
+        func_800AF388(arg0, var_a1);
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AF28C);
 
@@ -10115,7 +10140,14 @@ struct Unk* func_800AFAB4(s8 arg0, s16 x, s16 y, u8 arg3)
     return temp_v0;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AFB50);
+void func_800AFB50(struct VisualObj* arg0)
+{
+    if (arg0->base.state == 0) {
+        func_800AFB90(arg0);
+    } else {
+        func_800AFC4C(arg0);
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AFB90);
 
@@ -10149,7 +10181,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B06AC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B0804);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B0890);
+void func_800B0890(struct VisualObj* arg0)
+{
+    D_8010A430[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B08CC);
 
@@ -10157,7 +10192,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B0B48);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B0C78);
 
-void func_800B0C98(void)
+void func_800B0C98(struct VisualObj* arg0)
 {
 }
 
@@ -10165,13 +10200,23 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B0CA0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B10E4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1354);
+void func_800B1354(struct VisualObj* arg0)
+{
+    if (arg0->base.state == 0) {
+        func_800B1394(arg0);
+    } else {
+        func_800B1450(arg0);
+    }
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1394);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1450);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B14E8);
+void func_800B14E8(struct VisualObj* arg0)
+{
+    D_8010A4CC[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1524);
 
@@ -10183,7 +10228,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1758);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B17AC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B17CC);
+void func_800B17CC(struct VisualObj* arg0)
+{
+    D_8010A4E0[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1808);
 
@@ -10191,7 +10239,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1864);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B199C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B19BC);
+void func_800B19BC(struct VisualObj* arg0)
+{
+    D_8010A4EC[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B19F8);
 
@@ -10199,7 +10250,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1A48);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1AD8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1AF8);
+void func_800B1AF8(struct VisualObj* arg0)
+{
+    D_8010A520[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1B34);
 
@@ -10207,7 +10261,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1B74);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1C3C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1C5C);
+void func_800B1C5C(struct VisualObj* arg0)
+{
+    D_8010A52C[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1C98);
 
@@ -10215,7 +10272,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1CF4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1D4C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1D6C);
+void func_800B1D6C(struct VisualObj* arg0)
+{
+    D_8010A538[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1DA8);
 
@@ -10223,7 +10283,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1DE4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1E84);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1EA4);
+void func_800B1EA4(struct VisualObj* arg0)
+{
+    D_8010A544[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1EE0);
 
@@ -10231,7 +10294,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B1F78);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2070);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2090);
+void func_800B2090(struct VisualObj* arg0)
+{
+    D_8010A570[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B20CC);
 
@@ -10257,7 +10323,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2AD0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2C8C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2D48);
+void func_800B2D48(struct VisualObj* arg0)
+{
+    D_8010A5B0[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2D84);
 
@@ -10269,9 +10338,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B2F60);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3000);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3020);
+void func_800B3020(struct VisualObj* arg0)
+{
+    struct BaseObj* temp_v1 = arg0->unk50;
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3074);
+    arg0->base.x_pos.val = temp_v1->x_pos.val;
+    arg0->base.y_pos.val = temp_v1->y_pos.val;
+    D_8010A5C8[arg0->base.state](arg0);
+}
+
+void func_800B3074(struct VisualObj* arg0)
+{
+    D_8010A5D4[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B30B0);
 
@@ -10287,13 +10366,24 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3444);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B34EC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3508);
+void func_800B3508(struct VisualObj* arg0)
+{
+    func_80015DC8(arg0);
+    D_8010A5E4[arg0->base.unk2](arg0);
+    is_on_screen(arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B355C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B357C);
+void func_800B357C(struct VisualObj* arg0)
+{
+    D_8010A5F0[arg0->base.state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B35B8);
+void func_800B35B8(struct VisualObj* arg0)
+{
+    D_8010A64C[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B35F4);
 
@@ -10337,9 +10427,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3DE8);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3E20);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3E40);
+void func_800B3E40(struct VisualObj* arg0)
+{
+    D_8010A694[arg0->base.state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3E7C);
+void func_800B3E7C(struct VisualObj* arg0)
+{
+    D_8010A6A0[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3EB8);
 
@@ -10347,7 +10443,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B3FD4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B41AC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B41CC);
+void func_800B41CC(struct VisualObj* arg0)
+{
+    D_8010A6AC[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4208);
 
@@ -10363,7 +10462,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4578);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4598);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4610);
+void func_800B4610(struct VisualObj* arg0)
+{
+    D_8010A6C8[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B464C);
 
@@ -10395,7 +10497,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4AA8);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4B0C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4B64);
+void func_800B4B64(struct VisualObj* arg0)
+{
+    D_8010A704[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B4BA0);
 
@@ -10425,9 +10530,15 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B54B0);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B54EC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5534);
+void func_800B5534(struct VisualObj* arg0)
+{
+    D_8010A784[arg0->base.state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B5570);
+void func_800B5570(struct VisualObj* arg0)
+{
+    D_8010A790[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800B55AC);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -10037,9 +10037,11 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_800AEAA0);
 
 void func_800AEAC0(struct VisualObj* arg0)
 {
-    struct PlayerObj* var_a1 = &g_Entity;
+    struct PlayerObj* var_a1;
     if (g_Player.unkDE == 0) {
-        var_a1 = (struct PlayerObj*)(&g_Player.unkDE - 0xDE);
+        var_a1 = &g_Player;
+    } else {
+        var_a1 = &g_Entity;
     }
     D_8010A1A0[arg0->base.state](arg0, var_a1);
 }


### PR DESCRIPTION
List of remaining update funcs below:

```
glabel vis_object_update_funcs
/* E2FBC 800F27BC C0EA0A80 */ .word func_800AEAC0
/* E2FC0 800F27C0 18ED0A80 */ .word func_800AED18 /* skipped */
/* E2FC4 800F27C4 D8EE0A80 */ .word func_800AEED8
/* E2FC8 800F27C8 A0F60A80 */ .word func_800AF6A0 /* skipped */
/* E2FCC 800F27CC 50FB0A80 */ .word func_800AFB50
/* E2FD0 800F27D0 9CFC0A80 */ .word func_800AFC9C /* skipped */
/* E2FD4 800F27D4 78FF0A80 */ .word func_800AFF78 /* skipped */
/* E2FD8 800F27D8 2CF20A80 */ .word func_800AF22C
/* E2FDC 800F27DC 90080B80 */ .word func_800B0890
/* E2FE0 800F27E0 54130B80 */ .word func_800B1354
/* E2FE4 800F27E4 E8140B80 */ .word func_800B14E8
/* E2FE8 800F27E8 CC170B80 */ .word func_800B17CC
/* E2FEC 800F27EC BC190B80 */ .word func_800B19BC
/* E2FF0 800F27F0 F81A0B80 */ .word func_800B1AF8
/* E2FF4 800F27F4 5C1C0B80 */ .word func_800B1C5C
/* E2FF8 800F27F8 6C1D0B80 */ .word func_800B1D6C
/* E2FFC 800F27FC A41E0B80 */ .word func_800B1EA4
/* E3000 800F2800 90200B80 */ .word func_800B2090
/* E3004 800F2804 44250B80 */ .word func_800B2544 /* skipped */
/* E3008 800F2808 98260B80 */ .word func_800B2698 /* skipped */
/* E300C 800F280C 482D0B80 */ .word func_800B2D48
/* E3010 800F2810 20300B80 */ .word func_800B3020
/* E3014 800F2814 74300B80 */ .word func_800B3074
/* E3018 800F2818 7C350B80 */ .word func_800B357C
/* E301C 800F281C B8350B80 */ .word func_800B35B8
/* E3020 800F2820 403E0B80 */ .word func_800B3E40
/* E3024 800F2824 CC280B80 */ .word func_800B28CC /* skipped */
/* E3028 800F2828 3C2A0B80 */ .word func_800B2A3C /* skipped */
/* E302C 800F282C 7C3E0B80 */ .word func_800B3E7C
/* E3030 800F2830 CC410B80 */ .word func_800B41CC
/* E3034 800F2834 10460B80 */ .word func_800B4610
/* E3038 800F2838 644B0B80 */ .word func_800B4B64
/* E303C 800F283C 34550B80 */ .word func_800B5534
/* E3040 800F2840 D02A0B80 */ .word func_800B2AD0 /* skipped */
/* E3044 800F2844 70550B80 */ .word func_800B5570
/* E3048 800F2848 846B0C80 */ .word func_800C6B84 /* skipped */
/* E304C 800F284C 2C6C0C80 */ .word func_800C6C2C /* skipped */
/* E3050 800F2850 E46C0C80 */ .word func_800C6CE4 /* skipped */
/* E3054 800F2854 DC6E0C80 */ .word func_800C6EDC /* skipped */
/* E3058 800F2858 38830980 */ .word func_80098338 /* skipped */
.size vis_object_update_funcs, . - vis_object_update_funcs
```