### PR TITLE
Integrate all remaining trivial item update funcs

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -388,7 +388,9 @@ struct UnkObj {
 
 struct ItemObj {
     struct BaseObj base;
-    s8 pad18[0x50 - 0x18];
+    f32 unk18;
+    f32 unk1C;
+    s8 pad20[0x50 - 0x20];
     s32 unk50;
     s32 unk54;
     s8 pad58[0x61 - 0x58];

--- a/include/func_tables.h
+++ b/include/func_tables.h
@@ -466,35 +466,35 @@ void func_800BE540(struct EffectObj* arg0);
 void func_800BE800(struct EffectObj* arg0);
 void func_800BE83C(struct EffectObj* arg0);
 
-// D_800F2910
-void func_800BE9A0(void);
-void func_800BEBB4(void);
-void func_800BF730(void);
-void func_800C0404(void);
-void func_800C081C(void);
-void func_800C0E74(void);
-void func_800C1390(void);
-void func_800C1958(void);
-void func_800C1994(void);
-void func_800C20AC(void);
-void func_800C24E0(void);
-void func_800C2BE0(void);
-void func_800C3224(void);
-void func_800C351C(void);
-void func_800C3880(void);
-void func_800C3CF8(void);
-void func_800C3FEC(void);
-void func_800C42B0(void);
-void func_800C4544(void);
-void func_800C470C(void);
-void func_800C4CE4(void);
-void func_800C54FC(void);
-void func_800C5544(void);
-void func_800C5C4C(void);
-void func_800C6054(void);
-void func_800C42EC(void);
-void func_800C62DC(void);
-void func_800C7164(void);
+// D_800F2910 (item_object_update_funcs)
+void func_800BE9A0(struct ItemObj*);
+void func_800BEBB4(struct ItemObj*);
+void func_800BF730(struct ItemObj*);
+void func_800C0404(struct ItemObj*);
+void func_800C081C(struct ItemObj*);
+void func_800C0E74(struct ItemObj*);
+void func_800C1390(struct ItemObj*);
+void func_800C1958(struct ItemObj*);
+void func_800C1994(struct ItemObj*);
+void func_800C20AC(struct ItemObj*);
+void func_800C24E0(struct ItemObj*);
+void func_800C2BE0(struct ItemObj*);
+void func_800C3224(struct ItemObj*);
+void func_800C351C(struct ItemObj*);
+void func_800C3880(struct ItemObj*);
+void func_800C3CF8(struct ItemObj*);
+void func_800C3FEC(struct ItemObj*);
+void func_800C42B0(struct ItemObj*);
+void func_800C4544(struct ItemObj*);
+void func_800C470C(struct ItemObj*);
+void func_800C4CE4(struct ItemObj*);
+void func_800C54FC(struct ItemObj*);
+void func_800C5544(struct ItemObj*);
+void func_800C5C4C(struct ItemObj*);
+void func_800C6054(struct ItemObj*);
+void func_800C42EC(struct ItemObj*);
+void func_800C62DC(struct ItemObj*);
+void func_800C7164(struct ItemObj*);
 
 // D_800F2980 (misc_object_update_funcs)
 void func_800C7A68(struct MiscObj* arg0);
@@ -5345,15 +5345,17 @@ void func_800BE8E4(struct EffectObj*);
 void func_800BE960(struct EffectObj*);
 
 // D_8010C148
-void func_800BE9E8(void);
-void func_800BEB14(void);
-void func_800BEB94(void);
+extern void (*D_8010C148[])(struct ItemObj*);
+void func_800BE9E8(struct ItemObj*);
+void func_800BEB14(struct ItemObj*);
+void func_800BEB94(struct ItemObj*);
 
 // D_8010C2F0
-void func_800BEBFC(void);
-void func_800BED6C(void);
-void func_800BF530(void);
-void func_800BF5EC(void);
+extern void (*D_8010C2F0[])(struct ItemObj*);
+void func_800BEBFC(struct ItemObj*);
+void func_800BED6C(struct ItemObj*);
+void func_800BF530(struct ItemObj*);
+void func_800BF5EC(struct ItemObj*);
 
 // D_8010C300
 void func_800BEED4(void);
@@ -5362,205 +5364,240 @@ void func_800BF1FC(void);
 void func_800BF508(void);
 
 // D_8010C730
-void func_800BF76C(void);
-void func_800BFA00(void);
-void func_800BFB90(void);
-void func_800BFBB0(void);
+extern void (*D_8010C730[])(struct ItemObj*);
+void func_800BF76C(struct ItemObj*);
+void func_800BFA00(struct ItemObj*);
+void func_800BFB90(struct ItemObj*);
+void func_800BFBB0(struct ItemObj*);
 
 // D_8010C8A4
-void func_800C044C(void);
-void func_800C0558(void);
-void func_800C05FC(void);
-void func_800C07B8(void);
+extern void (*D_8010C8A4[])(struct ItemObj*);
+void func_800C044C(struct ItemObj*);
+void func_800C0558(struct ItemObj*);
+void func_800C05FC(struct ItemObj*);
+void func_800C07B8(struct ItemObj*);
 
 // D_8010C908
-void func_800C0864(void);
-void func_800C09C4(void);
-void func_800C0C78(void);
-void func_800C0D98(void);
+extern void (*D_8010C908[])(struct ItemObj*);
+void func_800C0864(struct ItemObj*);
+void func_800C09C4(struct ItemObj*);
+void func_800C0C78(struct ItemObj*);
+void func_800C0D98(struct ItemObj*);
 
 // D_8010CA9C
-void func_800C0EBC(void);
-void func_800C1050(void);
-void func_800C1224(void);
+extern void (*D_8010CA9C[])(struct ItemObj*);
+void func_800C0EBC(struct ItemObj*);
+void func_800C1050(struct ItemObj*);
+void func_800C1224(struct ItemObj*);
 
 // D_8010CAA8
-void func_800C13D8(void);
-void func_800C14F0(void);
-void func_800C1590(void);
-void func_800C165C(void);
-void func_800C169C(void);
+extern void (*D_8010CAA8[])(struct ItemObj*);
+void func_800C13D8(struct ItemObj*);
+void func_800C14F0(struct ItemObj*);
+void func_800C1590(struct ItemObj*);
+void func_800C165C(struct ItemObj*);
+void func_800C169C(struct ItemObj*);
 
 // D_8010CB5C
-void func_800C16F0(void);
-void func_800C1820(void);
-void func_800C1938(void);
+extern void (*D_8010CB5C[])(struct ItemObj*);
+void func_800C16F0(struct ItemObj*);
+void func_800C1820(struct ItemObj*);
+void func_800C1938(struct ItemObj*);
 
 // D_8010CC64
-void func_800C19F0(void);
-void func_800C1B54(void);
-void func_800C1FE4(void);
+extern void (*D_8010CC64[])(struct ItemObj*);
+void func_800C19F0(struct ItemObj*);
+void func_800C1B54(struct ItemObj*);
+void func_800C1FE4(struct ItemObj*);
 
 // D_8010CC70
-void func_800C1B98(void);
-void func_800C1C24(void);
-void func_800C1C88(void);
-void func_800C1D90(void);
-void func_800C1E10(void);
+extern void (*D_8010CC70[])(struct ItemObj*);
+void func_800C1B98(struct ItemObj*);
+void func_800C1C24(struct ItemObj*);
+void func_800C1C88(struct ItemObj*);
+void func_800C1D90(struct ItemObj*);
+void func_800C1E10(struct ItemObj*);
 
 // D_8010CC94
-void func_800C20F4(void);
-void func_800C229C(void);
-void func_800C24C0(void);
+extern void (*D_8010CC94[])(struct ItemObj*);
+void func_800C20F4(struct ItemObj*);
+void func_800C229C(struct ItemObj*);
+void func_800C24C0(struct ItemObj*);
 
 // D_8010CE34
-void func_800C2528(void);
-void func_800C2638(void);
-void func_800C27D8(void);
-void func_800C2850(void);
-void func_800C28E8(void);
-void func_800C2918(void);
+extern void (*D_8010CE34[])(struct ItemObj*);
+void func_800C2528(struct ItemObj*);
+void func_800C2638(struct ItemObj*);
+void func_800C27D8(struct ItemObj*);
+void func_800C2850(struct ItemObj*);
+void func_800C28E8(struct ItemObj*);
+void func_800C2918(struct ItemObj*);
 
 // D_8010CFAC
-void func_800C2C3C(void);
-void func_800C2D6C(void);
-void func_800C2DE0(void);
-void func_800C2E00(void);
+extern void (*D_8010CFAC[])(struct ItemObj*);
+void func_800C2C3C(struct ItemObj*);
+void func_800C2D6C(struct ItemObj*);
+void func_800C2DE0(struct ItemObj*);
+void func_800C2E00(struct ItemObj*);
 
 // D_8010CFBC
-void func_800C2E20(void);
-void func_800C2EAC(void);
-void func_800C2F18(void);
-void func_800C31C4(void);
+extern void (*D_8010CFBC[])(struct ItemObj*);
+void func_800C2E20(struct ItemObj*);
+void func_800C2EAC(struct ItemObj*);
+void func_800C2F18(struct ItemObj*);
+void func_800C31C4(struct ItemObj*);
 
 // D_8010CFD0
-void func_800C2F54(void);
-void func_800C3030(void);
-void func_800C3114(void);
-void func_800C3198(void);
+extern void (*D_8010CFD0[])(struct ItemObj*);
+void func_800C2F54(struct ItemObj*);
+void func_800C3030(struct ItemObj*);
+void func_800C3114(struct ItemObj*);
+void func_800C3198(struct ItemObj*);
 
 // D_8010CFE0
-void func_800C32BC(void);
-void func_800C3364(void);
-void func_800C3438(void);
-void func_800C3484(void);
+extern void (*D_8010CFE0[])(struct ItemObj*);
+void func_800C32BC(struct ItemObj*);
+void func_800C3364(struct ItemObj*);
+void func_800C3438(struct ItemObj*);
+void func_800C3484(struct ItemObj*);
 
 // D_8010CFF0
-void func_800C34A4(void);
-void func_800C34D4(void);
-void func_800C34E8(void);
+extern void (*D_8010CFF0[])(struct ItemObj*);
+void func_800C34A4(struct ItemObj*);
+void func_800C34D4(struct ItemObj*);
+void func_800C34E8(struct ItemObj*);
 
 // D_8010D030
-void func_800C3578(void);
-void func_800C369C(void);
-void func_800C3828(void);
+extern void (*D_8010D030[])(struct ItemObj*);
+void func_800C3578(struct ItemObj*);
+void func_800C369C(struct ItemObj*);
+void func_800C3828(struct ItemObj*);
 
 // D_8010D040
-void func_800C38C8(void);
-void func_800C39AC(void);
-void func_800C3A0C(void);
-void func_800C3A20(void);
+extern void (*D_8010D040[])(struct ItemObj*);
+void func_800C38C8(struct ItemObj*);
+void func_800C39AC(struct ItemObj*);
+void func_800C3A0C(struct ItemObj*);
+void func_800C3A20(struct ItemObj*);
 
 // D_8010D050
-void func_800C3A40(void);
-void func_800C3BA4(void);
-void func_800C3C9C(void);
-void func_800C3CE4(void);
+extern void (*D_8010D050[])(struct ItemObj*);
+void func_800C3A40(struct ItemObj*);
+void func_800C3BA4(struct ItemObj*);
+void func_800C3C9C(struct ItemObj*);
+void func_800C3CE4(struct ItemObj*);
 
 // D_8010D064
-void func_800C3A7C(void);
-void func_800C3AD4(void);
-void func_800C3B40(void);
+extern void (*D_8010D064[])(struct ItemObj*);
+void func_800C3A7C(struct ItemObj*);
+void func_800C3AD4(struct ItemObj*);
+void func_800C3B40(struct ItemObj*);
 
 // D_8010D070
-void func_800C3D40(void);
-void func_800C3E4C(void);
-void func_800C3F98(void);
+extern void (*D_8010D070[])(struct ItemObj*);
+void func_800C3D40(struct ItemObj*);
+void func_800C3E4C(struct ItemObj*);
+void func_800C3F98(struct ItemObj*);
 
 // D_8010D100
-void func_800C40A4(void);
-void func_800C40F0(void);
+extern void (*D_8010D100[])(struct ItemObj*);
+void func_800C40A4(struct ItemObj*);
+void func_800C40F0(struct ItemObj*);
 
 // D_8010D18C
-void func_800C413C(void);
-void func_800C41C8(void);
-void func_800C4290(void);
+extern void (*D_8010D18C[])(struct ItemObj*);
+void func_800C413C(struct ItemObj*);
+void func_800C41C8(struct ItemObj*);
+void func_800C4290(struct ItemObj*);
 
 // D_8010D1CC
-void func_800C458C(void);
-void func_800C460C(void);
-void func_800C4678(void);
+extern void (*D_8010D1CC[])(struct ItemObj*);
+void func_800C458C(struct ItemObj*);
+void func_800C460C(struct ItemObj*);
+void func_800C4678(struct ItemObj*);
 
 // D_8010D1F4
-void func_800C4778(void);
-void func_800C49BC(void);
-void func_800C4BE4(void);
+extern void (*D_8010D1F4[])(struct ItemObj*);
+void func_800C4778(struct ItemObj*);
+void func_800C49BC(struct ItemObj*);
+void func_800C4BE4(struct ItemObj*);
 
 // D_8010D200
-void func_800C4BEC(void);
-void func_800C4C64(void);
-void func_800C4BE4(void);
+extern void (*D_8010D200[])(struct ItemObj*);
+void func_800C4BEC(struct ItemObj*);
+void func_800C4C64(struct ItemObj*);
+void func_800C4BE4(struct ItemObj*);
 
 // D_8010D234
-void func_800C4D20(void);
-void func_800C4E78(void);
-void func_800C5058(void);
+extern void (*D_8010D234[])(struct ItemObj*);
+void func_800C4D20(struct ItemObj*);
+void func_800C4E78(struct ItemObj*);
+void func_800C5058(struct ItemObj*);
 
 // D_8010D240
-void func_800C4EC8(void);
-void func_800C4F04(void);
-void func_800C4F40(void);
+extern void (*D_8010D240[])(struct ItemObj*);
+void func_800C4EC8(struct ItemObj*);
+void func_800C4F04(struct ItemObj*);
+void func_800C4F40(struct ItemObj*);
 
 // D_8010D250
-void func_800C52CC(void);
-void func_800C5444(void);
-void func_800C54DC(void);
+extern void (*D_8010D250[])(struct ItemObj*);
+void func_800C52CC(struct ItemObj*);
+void func_800C5444(struct ItemObj*);
+void func_800C54DC(struct ItemObj*);
 
 // D_8010D318
-void func_800C5580(void);
-void func_800C56B4(void);
-void func_800C56F0(void);
-void func_800C5710(void);
+extern void (*D_8010D318[])(struct ItemObj*);
+void func_800C5580(struct ItemObj*);
+void func_800C56B4(struct ItemObj*);
+void func_800C56F0(struct ItemObj*);
+void func_800C5710(struct ItemObj*);
 
 // D_8010D328
-void func_800C5774(void);
-void func_800C580C(void);
+extern void (*D_8010D328[])(struct ItemObj*);
+void func_800C5774(struct ItemObj*);
+void func_800C580C(struct ItemObj*);
 
 // D_8010D344
-void func_800C5C88(void);
-void func_800C5F90(void);
-void func_800C5F70(void);
+extern void (*D_8010D344[])(struct ItemObj*);
+void func_800C5C88(struct ItemObj*);
+void func_800C5F90(struct ItemObj*);
+void func_800C5F70(struct ItemObj*);
 
 // D_8010D350
-void func_800C5D44(void);
-void func_800C5F04(void);
-void func_800C5F50(void);
-void func_800C5F30(void);
+extern void (*D_8010D350[])(struct ItemObj*);
+void func_800C5D44(struct ItemObj*);
+void func_800C5F04(struct ItemObj*);
+void func_800C5F50(struct ItemObj*);
+void func_800C5F30(struct ItemObj*);
 
 // D_8010D3AC
-void func_800C609C(void);
-void func_800C6198(void);
-void func_800C6228(void);
+extern void (*D_8010D3AC[])(struct ItemObj*);
+void func_800C609C(struct ItemObj*);
+void func_800C6198(struct ItemObj*);
+void func_800C6228(struct ItemObj*);
 
 // D_8010D3E0
-void func_800C670C(void);
-void func_800C6814(void);
-void func_800C6894(void);
-void func_800C68E0(void);
-void func_800C6928(void);
-void func_800C6984(void);
-void func_800C6A0C(void);
-void func_800C6A7C(void);
-void func_800C6ACC(void);
-void func_800C6B30(void);
-void func_800C6B7C(void);
+extern void (*D_8010D3E0[])(struct ItemObj*);
+void func_800C670C(struct ItemObj*);
+void func_800C6814(struct ItemObj*);
+void func_800C6894(struct ItemObj*);
+void func_800C68E0(struct ItemObj*);
+void func_800C6928(struct ItemObj*);
+void func_800C6984(struct ItemObj*);
+void func_800C6A0C(struct ItemObj*);
+void func_800C6A7C(struct ItemObj*);
+void func_800C6ACC(struct ItemObj*);
+void func_800C6B30(struct ItemObj*);
+void func_800C6B7C(struct ItemObj*);
 
 // D_8010D990
-void func_800C71C0(void);
-void func_800C7460(void);
-void func_800C74D4(void);
-void func_800C7538(void);
-void func_800C7558(void);
+extern void (*D_8010D990[])(struct ItemObj*);
+void func_800C71C0(struct ItemObj*);
+void func_800C7460(struct ItemObj*);
+void func_800C74D4(struct ItemObj*);
+void func_800C7538(struct ItemObj*);
+void func_800C7558(struct ItemObj*);
 
 // D_8010D9A4
 void func_800C7578(void);

--- a/src/main/A7878.c
+++ b/src/main/A7878.c
@@ -723,7 +723,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE8E4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE960);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE9A0);
+void func_800BE9A0(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010C148[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BE9E8);
 
@@ -731,7 +736,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BEB14);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BEB94);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BEBB4);
+void func_800BEBB4(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010C2F0[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BEBFC);
 
@@ -753,7 +763,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BF60C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BF638);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BF730);
+void func_800BF730(struct ItemObj* arg0)
+{
+    D_8010C730[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800BF76C);
 
@@ -773,7 +786,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C00BC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C03BC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0404);
+void func_800C0404(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010C8A4[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C044C);
 
@@ -783,7 +801,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C05FC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C07B8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C081C);
+void func_800C081C(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010C908[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0864);
 
@@ -795,7 +818,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0D98);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0DFC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0E74);
+void func_800C0E74(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CA9C[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C0EBC);
 
@@ -807,7 +835,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1244);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1318);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1390);
+void func_800C1390(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CAA8[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C13D8);
 
@@ -825,9 +858,18 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1820);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1938);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1958);
+void func_800C1958(struct ItemObj* arg0)
+{
+    D_8010CB5C[arg0->base.state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1994);
+void func_800C1994(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CC64[arg0->base.state](arg0);
+    is_on_screen(arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C19F0);
 
@@ -849,7 +891,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C1FE4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C204C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C20AC);
+void func_800C20AC(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CC94[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C20F4);
 
@@ -857,7 +904,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C229C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C24C0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C24E0);
+void func_800C24E0(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CE34[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C2528);
 
@@ -875,7 +927,13 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C2A04);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C2AF0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C2BE0);
+void func_800C2BE0(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010CFAC[arg0->base.state](arg0);
+    func_8002E184(arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C2C3C);
 
@@ -915,13 +973,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C34A4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C34D4);
 
-void func_800C34E8(void)
+void func_800C34E8(struct ItemObj* arg0)
 {
 }
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C34F0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C351C);
+void func_800C351C(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D030[arg0->base.state](arg0);
+    is_on_screen(arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3578);
 
@@ -933,7 +997,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C37C4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3828);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3880);
+void func_800C3880(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D040[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C38C8);
 
@@ -957,7 +1026,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3C9C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3CE4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3CF8);
+void func_800C3CF8(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D070[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C3D40);
 
@@ -977,11 +1051,19 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C41C8);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4290);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C42B0);
+void func_800C42B0(struct ItemObj* arg0)
+{
+    D_8010D18C[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C42EC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4544);
+void func_800C4544(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D1CC[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C458C);
 
@@ -995,7 +1077,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4778);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C49BC);
 
-void func_800C4BE4(void)
+void func_800C4BE4(struct ItemObj* arg0)
 {
 }
 
@@ -1003,7 +1085,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4BEC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4C64);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4CE4);
+void func_800C4CE4(struct ItemObj* arg0)
+{
+    D_8010D234[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C4D20);
 
@@ -1029,9 +1114,17 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5444);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C54DC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C54FC);
+void func_800C54FC(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D250[arg0->base.state](arg0);
+}
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5544);
+void func_800C5544(struct ItemObj* arg0)
+{
+    D_8010D318[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5580);
 
@@ -1053,7 +1146,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5B5C);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5BCC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5C4C);
+void func_800C5C4C(struct ItemObj* arg0)
+{
+    D_8010D344[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5C88);
 
@@ -1069,7 +1165,12 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5F70);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C5F90);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C6054);
+void func_800C6054(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D3AC[arg0->base.state](arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C609C);
 
@@ -1105,7 +1206,7 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C6ACC);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C6B30);
 
-void func_800C6B7C(void)
+void func_800C6B7C(struct ItemObj* arg0)
 {
 }
 
@@ -1119,7 +1220,13 @@ INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C6DD4);
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C6EDC);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C7164);
+void func_800C7164(struct ItemObj* arg0)
+{
+    arg0->unk18.val = arg0->base.x_pos.val;
+    arg0->unk1C.val = arg0->base.y_pos.val;
+    D_8010D990[arg0->base.state](arg0);
+    func_8002E184(arg0);
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/A7878", func_800C71C0);
 


### PR DESCRIPTION
List of skipped (non-trivial) funcs:

```
/* E3140 800F2940 24320C80 */ .word func_800C3224 /* skipped */
/* E3150 800F2950 EC3F0C80 */ .word func_800C3FEC /* skipped */
/* E315C 800F295C 0C470C80 */ .word func_800C470C /* skipped */
/* E3174 800F2974 EC420C80 */ .word func_800C42EC /* skipped */
/* E3178 800F2978 DC620C80 */ .word func_800C62DC /* skipped */
```