### PR TITLE
Render symbols

### DIFF
--- a/config/symbols.us.txt
+++ b/config/symbols.us.txt
@@ -499,6 +499,14 @@ temp3 = 0x80139830; // size:0x200
 temp4 = 0x80139C30; // size:0x100
 temp5 = 0x80139E30; // size:0x78
 
+g_FilterModeR = 0x80175E9C;
+g_FilterModeG = 0x80141BE4;
+g_FilterModeB = 0x8013E1BC;
+
+g_FilterAmountR = 0x80175EA0;
+g_FilterAmountG = 0x80141BE6;
+g_FilterAmountB = 0x8013E1BE;
+
 draw_infos = 0x80166C10;
 draw_infos_0_dispenv_isinter = 0x80166c20;
 draw_infos_0_dispenv_isrgb24 = 0x80166c21;

--- a/config/symbols.us.txt
+++ b/config/symbols.us.txt
@@ -507,6 +507,10 @@ g_FilterAmountR = 0x80175EA0;
 g_FilterAmountG = 0x80141BE6;
 g_FilterAmountB = 0x8013E1BE;
 
+lastFilterAmountR = 0x80141F04;
+lastFilterAmountG = 0x8016DD9C;
+lastFilterAmountB = 0x801441BA;
+
 draw_infos = 0x80166C10;
 draw_infos_0_dispenv_isinter = 0x80166c20;
 draw_infos_0_dispenv_isrgb24 = 0x80166c21;

--- a/config/symbols.us.txt
+++ b/config/symbols.us.txt
@@ -493,6 +493,12 @@ cur_draw_info_dispenv_screen_w = 0x80142f8c;
 cur_draw_info_dispenv_isinter = 0x80142f90;
 cur_draw_info_drawenv = 0x80142f94;
 
+temp1 = 0x801499C8; // size:0xA000
+temp2 = 0x80169D98; // size:0x2000
+temp3 = 0x80139830; // size:0x200
+temp4 = 0x80139C30; // size:0x100
+temp5 = 0x80139E30; // size:0x78
+
 draw_infos = 0x80166C10;
 draw_infos_0_dispenv_isinter = 0x80166c20;
 draw_infos_0_dispenv_isrgb24 = 0x80166c21;

--- a/include/common.h
+++ b/include/common.h
@@ -1298,14 +1298,15 @@ extern s32 D_8013E188[4];
 // extern s32 D_8013E18C;
 // extern s32 D_8013E190;
 // extern s32 D_8013E194;
-extern s8 D_8013E1BC;
-extern s16 D_8013E1BE;
-extern s8 D_80141BE4;
-extern s16 D_80141BE6;
 extern s8 D_801754A0;
-extern s8 D_80175E9C;
-extern u16 D_80175EA0;
-extern s8 D_80175E9C;
+// 0 is color add mode, 1 is color subtract mode
+extern s8 g_FilterModeR;
+extern s8 g_FilterModeG;
+extern s8 g_FilterModeB;
+// how much to add or subtract to each channel
+extern u16 g_FilterAmountR;
+extern s16 g_FilterAmountB;
+extern s16 g_FilterAmountG;
 extern u16 controller_state;
 extern s8 D_801419FC;
 extern void* D_800F4508;

--- a/include/scratchpad.h
+++ b/include/scratchpad.h
@@ -13,5 +13,6 @@ struct Scratchpad1C {
 #define SP_1C (*(struct Scratchpad1C**)0x1F80001C)
 #define SP_PALETTE_ADDR 0x1F800028
 #define SP_PALETTE (*(volatile u32**)SP_PALETTE_ADDR)
+#define SP_DRAW_COUNT (*(s32*)0x1F800124)
 
 #endif

--- a/src/main/1A5BC.c
+++ b/src/main/1A5BC.c
@@ -280,12 +280,9 @@ void reset_objects(void)
         *a0++ = fill;
     }
 
-    D_8013E1BE = 0;
-    D_80141BE6 = 0;
-    D_80175EA0 = 0;
-    D_8013E1BC = 0;
-    D_80141BE4 = 0;
-    D_80175E9C = 0;
+    g_FilterAmountB = 0;
+    g_FilterAmountR = g_FilterAmountG = g_FilterAmountB = 0;
+    g_FilterModeR = g_FilterModeG = g_FilterModeB = 0;
     D_8013E188[0] = 0;
     D_8013E188[1] = 0;
     D_8013E188[2] = 0;
@@ -1320,14 +1317,14 @@ void func_8002F9EC(struct EngineObj* arg0)
     struct BaseObj* obj;
     u32 var_a0;
 
-    if (D_80175EA0 == 0x1F) {
+    if (g_FilterAmountR == 0x1F) {
         func_8002B560(2, 0xC);
         for (var_a0 = 0; var_a0 < 4; var_a0++) {
             D_8013E188[var_a0] = 0;
         }
-        D_80175EA0 = 0;
-        D_80141BE6 = 0;
-        D_8013E1BE = 0;
+        g_FilterAmountR = 0;
+        g_FilterAmountG = 0;
+        g_FilterAmountB = 0;
         need_palette_load |= 1;
         obj = (struct BaseObj*)find_free_misc_obj();
         if (obj != NULL) {

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -801,9 +801,9 @@ void func_80017340(void)
     s8 end;
     u8 var_v0;
 
-    *(void**)0x1F800100 = &temp1[*(s32*)0x1F800000];
-    *(void**)0x1F800104 = &temp2[*(s32*)0x1F800000];
-    *(void**)0x1F800110 = &temp1[*(s32*)0x1F800000];
+    *(void**)0x1F800100 = &temp1[SP_DRAW_INFO_POS];
+    *(void**)0x1F800104 = &temp2[SP_DRAW_INFO_POS];
+    *(void**)0x1F800110 = &temp1[SP_DRAW_INFO_POS];
 
     func_80017E84();
 
@@ -2975,7 +2975,6 @@ void init_objects(void)
     struct MiscObj* var_s0_7;
     struct UnkObj* var_s0_8;
     struct QuadObj* var_s0_9;
-    s32 temp_a0;
     void* temp_v1;
     void* temp_v1_2;
     void* temp_v1_3;
@@ -2990,13 +2989,12 @@ void init_objects(void)
     struct PlayerObj* ptr3 = &g_Entity;
     struct QuxObj* ptr4;
 
-    temp_a0 = *(s32*)0x1F800000;
-    *(s32*)0x1F800124 = 0;
-    *(void**)0x1F800100 = &temp1[temp_a0]; // size 0xA000
-    *(void**)0x1F800104 = &temp2[temp_a0]; // size 0x2000
-    *(void**)0x1F800108 = &temp3[temp_a0]; // size 0x200
-    *(void**)0x1F80010C = &temp4[temp_a0]; // size 0x100
-    *(void**)0x1F800110 = &temp5[temp_a0]; // size 0x78
+    SP_DRAW_COUNT = 0;
+    *(void**)0x1F800100 = &temp1[SP_DRAW_INFO_POS]; // size 0xA000
+    *(void**)0x1F800104 = &temp2[SP_DRAW_INFO_POS]; // size 0x2000
+    *(void**)0x1F800108 = &temp3[SP_DRAW_INFO_POS]; // size 0x200
+    *(void**)0x1F80010C = &temp4[SP_DRAW_INFO_POS]; // size 0x100
+    *(void**)0x1F800110 = &temp5[SP_DRAW_INFO_POS]; // size 0x78
 
     func_80024E70(); // ???
     func_800241E8(); // initialize some memory around D_8013BC40 and D_8013E1E8
@@ -3172,12 +3170,10 @@ INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002588C);
 
 void func_80025CDC(void) {
     struct UnkObj* var_s0;
-    s32 temp_v1;
 
-    temp_v1 = *(s32* )0x1F800000;
-    *(s32* )0x1F800124 = 0;
-    *(void** )0x1F800100 = &temp1[temp_v1];
-    *(void** )0x1F800104 = &temp2[temp_v1];
+    SP_DRAW_COUNT = 0;
+    *(void** )0x1F800100 = &temp1[SP_DRAW_INFO_POS];
+    *(void** )0x1F800104 = &temp2[SP_DRAW_INFO_POS];
     func_800241E8();
     for (var_s0 = &unk_objects[0]; var_s0 < &unk_objects[COUNT(unk_objects)]; var_s0++) {
         if (var_s0->base.on_screen != 0) {

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -1453,9 +1453,7 @@ void func_8001D7D0(struct GameInfo* /* D_80173C70 */ arg0)
     D_80141BDE[0] = 0;
     func_80016F0C();
     func_80015930(0xFF, 0);
-    D_8013E1BE = 0;
-    D_80141BE6 = 0;
-    D_80175EA0 = 0;
+    g_FilterAmountR = g_FilterAmountG = g_FilterAmountB = 0;
     D_8013E188[0] = 0;
     D_8013E188[1] = 0;
     D_8013E188[2] = 0;
@@ -1685,9 +1683,7 @@ void func_8001E000(struct GameInfo* arg0)
         return;
     }
     if (D_80139690->active == 0) {
-        D_8013E1BE = 0;
-        D_80141BE6 = 0;
-        D_80175EA0 = 0;
+        g_FilterAmountR = g_FilterAmountG = g_FilterAmountB = 0;
         D_8013E188[0] = 0;
         D_8013E188[1] = 0;
         D_8013E188[2] = 0;
@@ -1809,9 +1805,7 @@ void func_8001E708(struct GameInfo* arg0)
         func_80016F0C();
         func_8001540C(0, 0x22, 0);
         arg0->mode = 0xC;
-        D_8013E1BE = 0;
-        D_80141BE6 = 0;
-        D_80175EA0 = 0;
+        g_FilterAmountR = g_FilterAmountG = g_FilterAmountB = 0;
         D_8013E188[0] = 0;
         D_8013E188[1] = 0;
         D_8013E188[2] = 0;

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -27,11 +27,11 @@ extern s32 D_80139514;
 extern u8 D_80139554;
 extern s8 D_80139568;
 extern s16 D_8013955C;
-extern struct Temp1 D_801499C8[];
-extern struct Temp2 D_80169D98[];
-extern struct Temp3 D_80139830[];
-extern struct Temp4 D_80139C30[];
-extern struct Temp5 D_80139E30[];
+extern struct Temp1 temp1[];
+extern struct Temp2 temp2[];
+extern struct Temp3 temp3[];
+extern struct Temp4 temp4[];
+extern struct Temp5 temp5[];
 extern u8 D_80173C84;
 extern s32 D_80175EE8[];
 
@@ -130,8 +130,8 @@ void func_80013404(u8 arg0)
     s8* a0;
     s8* var_v0;
     struct EngineObj* ptr = &engine_obj;
-    *(void**)0x1F800100 = &D_801499C8[SP_DRAW_INFO_POS];
-    *(void**)0x1F800104 = &D_80169D98[SP_DRAW_INFO_POS];
+    *(void**)0x1F800100 = &temp1[SP_DRAW_INFO_POS];
+    *(void**)0x1F800104 = &temp2[SP_DRAW_INFO_POS];
 
     func_800160F4();
 
@@ -801,9 +801,9 @@ void func_80017340(void)
     s8 end;
     u8 var_v0;
 
-    *(void**)0x1F800100 = &D_801499C8[*(s32*)0x1F800000];
-    *(void**)0x1F800104 = &D_80169D98[*(s32*)0x1F800000];
-    *(void**)0x1F800110 = &D_801499C8[*(s32*)0x1F800000];
+    *(void**)0x1F800100 = &temp1[*(s32*)0x1F800000];
+    *(void**)0x1F800104 = &temp2[*(s32*)0x1F800000];
+    *(void**)0x1F800110 = &temp1[*(s32*)0x1F800000];
 
     func_80017E84();
 
@@ -2992,11 +2992,11 @@ void init_objects(void)
 
     temp_a0 = *(s32*)0x1F800000;
     *(s32*)0x1F800124 = 0;
-    *(void**)0x1F800100 = &D_801499C8[temp_a0]; // size 0xA000
-    *(void**)0x1F800104 = &D_80169D98[temp_a0]; // size 0x2000
-    *(void**)0x1F800108 = &D_80139830[temp_a0]; // size 0x200
-    *(void**)0x1F80010C = &D_80139C30[temp_a0]; // size 0x100
-    *(void**)0x1F800110 = &D_80139E30[temp_a0]; // size 0x78
+    *(void**)0x1F800100 = &temp1[temp_a0]; // size 0xA000
+    *(void**)0x1F800104 = &temp2[temp_a0]; // size 0x2000
+    *(void**)0x1F800108 = &temp3[temp_a0]; // size 0x200
+    *(void**)0x1F80010C = &temp4[temp_a0]; // size 0x100
+    *(void**)0x1F800110 = &temp5[temp_a0]; // size 0x78
 
     func_80024E70(); // ???
     func_800241E8(); // initialize some memory around D_8013BC40 and D_8013E1E8
@@ -3170,7 +3170,22 @@ void func_800257BC(struct PlayerObj* arg0)
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002588C);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80025CDC);
+void func_80025CDC(void) {
+    struct UnkObj* var_s0;
+    s32 temp_v1;
+
+    temp_v1 = *(s32* )0x1F800000;
+    *(s32* )0x1F800124 = 0;
+    *(void** )0x1F800100 = &temp1[temp_v1];
+    *(void** )0x1F800104 = &temp2[temp_v1];
+    func_800241E8();
+    for (var_s0 = &unk_objects[0]; var_s0 < &unk_objects[COUNT(unk_objects)]; var_s0++) {
+        if (var_s0->base.on_screen != 0) {
+            func_80024334(var_s0);
+        }
+    }
+    func_80024260();
+}
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_80025DA0);
 

--- a/src/main/323C.c
+++ b/src/main/323C.c
@@ -3168,12 +3168,13 @@ void func_800257BC(struct PlayerObj* arg0)
 
 INCLUDE_ASM("asm/us/main/nonmatchings/323C", func_8002588C);
 
-void func_80025CDC(void) {
+void func_80025CDC(void)
+{
     struct UnkObj* var_s0;
 
     SP_DRAW_COUNT = 0;
-    *(void** )0x1F800100 = &temp1[SP_DRAW_INFO_POS];
-    *(void** )0x1F800104 = &temp2[SP_DRAW_INFO_POS];
+    *(void**)0x1F800100 = &temp1[SP_DRAW_INFO_POS];
+    *(void**)0x1F800104 = &temp2[SP_DRAW_INFO_POS];
     func_800241E8();
     for (var_s0 = &unk_objects[0]; var_s0 < &unk_objects[COUNT(unk_objects)]; var_s0++) {
         if (var_s0->base.on_screen != 0) {

--- a/src/main/character_select.c
+++ b/src/main/character_select.c
@@ -66,15 +66,15 @@ void character_select_state_1(struct EngineObj* arg0)
 void character_select_state_2_substate_0(struct EngineObj* arg0)
 {
     if (arg0->unk4 != 0) {
-        D_80175EA0 = 0x1F;
-        D_80141BE6 = 0x3E0;
-        D_8013E1BE = 0x7C00;
+        g_FilterAmountR = 0x1F;
+        g_FilterAmountG = 0x3E0;
+        g_FilterAmountB = 0x7C00;
         arg0->unk4--;
     } else {
         arg0->unk2++;
-        D_80175EA0 = 0;
-        D_80141BE6 = 0;
-        D_8013E1BE = 0;
+        g_FilterAmountR = 0;
+        g_FilterAmountG = 0;
+        g_FilterAmountB = 0;
         D_8013E188[0] = 0;
         D_8013E188[1] = 0;
         D_8013E188[2] = 0;

--- a/src/main/effect_objs.c
+++ b/src/main/effect_objs.c
@@ -54,22 +54,18 @@ void func_800B599C(struct EffectObj* arg0)
         for (i = 0; i < 4; i++) {
             D_8013E188[i] = D_8010B23C[arg0->unk2][i];
         }
-        D_80175E9C = arg0->ext.scaling_x.unk14->unk3 & 1;
-        D_80141BE4 = arg0->ext.scaling_x.unk14->unk3 & 2;
-        D_8013E1BC = arg0->ext.scaling_x.unk14->unk3 & 4;
+        g_FilterModeR = arg0->ext.scaling_x.unk14->unk3 & 1;
+        g_FilterModeG = arg0->ext.scaling_x.unk14->unk3 & 2;
+        g_FilterModeB = arg0->ext.scaling_x.unk14->unk3 & 4;
         color = arg0->ext.scaling_x.unk14->unk0;
-        D_80175EA0 = color & 0x1F;
-        D_80141BE6 = color & 0x3E0;
-        D_8013E1BE = color & 0x7C00;
+        g_FilterAmountR = color & 0x1F;
+        g_FilterAmountG = color & 0x3E0;
+        g_FilterAmountB = color & 0x7C00;
         arg0->state++;
         return;
     }
-    D_8013E1BE = 0;
-    D_80141BE6 = 0;
-    D_80175EA0 = 0;
-    D_8013E1BC = 0;
-    D_80141BE4 = 0;
-    D_80175E9C = 0;
+    g_FilterAmountR = g_FilterAmountG = g_FilterAmountB = 0;
+    g_FilterModeR = g_FilterModeG = g_FilterModeB = 0;
 
     for (current = &effect_objects[0]; current < &effect_objects[0x20]; current++) {
         if (current->unk2 == 2 && current != arg0) {
@@ -94,12 +90,12 @@ void func_800B5B54(struct EffectObj* arg0)
         }
         color = arg0->ext.scaling_x.unk14->unk0;
         arg0->ext.scaling_x.unk18 = arg0->ext.scaling_x.unk14->unk2;
-        D_80175EA0 = color & 0x1F;
-        D_80141BE6 = color & 0x3E0;
-        D_8013E1BE = color & 0x7C00;
-        D_80175E9C = arg0->ext.scaling_x.unk14->unk3 & 1;
-        D_80141BE4 = arg0->ext.scaling_x.unk14->unk3 & 2;
-        D_8013E1BC = arg0->ext.scaling_x.unk14->unk3 & 4;
+        g_FilterAmountR = color & 0x1F;
+        g_FilterAmountG = color & 0x3E0;
+        g_FilterAmountB = color & 0x7C00;
+        g_FilterModeR = arg0->ext.scaling_x.unk14->unk3 & 1;
+        g_FilterModeG = arg0->ext.scaling_x.unk14->unk3 & 2;
+        g_FilterModeB = arg0->ext.scaling_x.unk14->unk3 & 4;
         need_palette_load |= 5;
     }
 }


### PR DESCRIPTION
These symbols aren't really accessed elsewhere but I'm trying to map out the remaining bss memory. From https://github.com/sozud/mmx4/pull/121#discussion_r1807633313 these seem to be used for render calls.

If we can fix the final swap in https://decomp.me/scratch/7kdDB I think it'll clarify more of how rendering works.